### PR TITLE
Add basic prompt implementation support

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod looper;
+pub mod prompt;
 pub mod state;
 
 use crate::ui::UI;

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -1,7 +1,7 @@
 use std::cmp::min;
 
 use crate::{
-    editing::{buffer::MemoryBuffer, text::TextLine, window::Window, Buffer, Resizable, Size},
+    editing::{buffer::MemoryBuffer, window::Window, Buffer, Resizable, Size},
     tui::measure::Measurable,
 };
 

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -44,6 +44,7 @@ impl Prompt {
     pub fn clear(&mut self) {
         self.buffer.clear();
         self.window.focused = false;
+        self.handle_content_change();
     }
 
     pub fn handle_content_change(&mut self) {

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -1,0 +1,46 @@
+use std::cmp::min;
+
+use crate::{
+    editing::{buffer::MemoryBuffer, text::TextLine, window::Window, Buffer, Resizable, Size},
+    tui::measure::Measurable,
+};
+
+/// The Prompt is used to render prompts, cmdline mode, search modes, etc
+pub struct Prompt {
+    pub buffer: Box<dyn Buffer>,
+    pub window: Window,
+    max_height: u16,
+}
+
+impl Default for Prompt {
+    fn default() -> Self {
+        Self {
+            buffer: Box::new(MemoryBuffer::new(0)),
+            window: Window::new(0, 0),
+            max_height: 10,
+        }
+    }
+}
+
+impl Prompt {
+    pub fn handle_content_change(&mut self) {
+        self.resize(Size {
+            w: self.window.size.w,
+            h: self.max_height,
+        });
+    }
+}
+
+impl Resizable for Prompt {
+    fn resize(&mut self, new_size: crate::editing::Size) {
+        let lines: Vec<&TextLine> = (0..self.buffer.lines_count())
+            .map(|i| self.buffer.get(i))
+            .collect();
+        let height = lines.measure_height(new_size.w);
+        self.max_height = new_size.h;
+        self.window.resize(Size {
+            w: new_size.w,
+            h: min(height, new_size.h),
+        });
+    }
+}

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -33,10 +33,7 @@ impl Prompt {
 
 impl Resizable for Prompt {
     fn resize(&mut self, new_size: crate::editing::Size) {
-        let lines: Vec<&TextLine> = (0..self.buffer.lines_count())
-            .map(|i| self.buffer.get(i))
-            .collect();
-        let height = lines.measure_height(new_size.w);
+        let height = self.buffer.measure_height(new_size.w);
         self.max_height = new_size.h;
         self.window.resize(Size {
             w: new_size.w,

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -23,6 +23,10 @@ impl Default for Prompt {
 }
 
 impl Prompt {
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+    }
+
     pub fn handle_content_change(&mut self) {
         self.resize(Size {
             w: self.window.size.w,

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -1,30 +1,41 @@
 use std::cmp::min;
 
 use crate::{
-    editing::{buffer::MemoryBuffer, window::Window, Buffer, Resizable, Size},
+    editing::{buffer::MemoryBuffer, text::TextLine, window::Window, Buffer, Resizable, Size},
     tui::measure::Measurable,
 };
 
 /// The Prompt is used to render prompts, cmdline mode, search modes, etc
 pub struct Prompt {
     pub buffer: Box<dyn Buffer>,
-    pub window: Window,
+    pub window: Box<Window>,
     max_height: u16,
 }
 
 impl Default for Prompt {
     fn default() -> Self {
+        let mut window = Window::new(0, 0);
+        window.focused = false;
+
         Self {
             buffer: Box::new(MemoryBuffer::new(0)),
-            window: Window::new(0, 0),
+            window: Box::new(window),
             max_height: 10,
         }
     }
 }
 
 impl Prompt {
+    pub fn activate(&mut self, prompt: TextLine) {
+        self.clear();
+        self.window.focused = true;
+        self.buffer.append(prompt.into());
+        self.handle_content_change();
+    }
+
     pub fn clear(&mut self) {
         self.buffer.clear();
+        self.window.focused = false;
     }
 
     pub fn handle_content_change(&mut self) {

--- a/src/app/prompt.rs
+++ b/src/app/prompt.rs
@@ -1,7 +1,10 @@
 use std::cmp::min;
 
 use crate::{
-    editing::{buffer::MemoryBuffer, text::TextLine, window::Window, Buffer, Resizable, Size},
+    editing::{
+        buffer::MemoryBuffer, text::TextLine, window::Window, Buffer, CursorPosition, Resizable,
+        Size,
+    },
     tui::measure::Measurable,
 };
 
@@ -29,6 +32,11 @@ impl Prompt {
     pub fn activate(&mut self, prompt: TextLine) {
         self.clear();
         self.window.focused = true;
+        self.window.inserting = true;
+        self.window.cursor = CursorPosition {
+            line: 0,
+            col: prompt.width() as u16,
+        };
         self.buffer.append(prompt.into());
         self.handle_content_change();
     }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -135,10 +135,10 @@ impl MotionContext for AppState {
     }
 
     fn window(&self) -> &Box<Window> {
-        self.tabpages.current_tab().current_window()
+        self.current_window()
     }
 
     fn window_mut(&mut self) -> &mut Box<Window> {
-        self.tabpages.current_tab_mut().current_window_mut()
+        self.current_window_mut()
     }
 }

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -22,10 +22,20 @@ pub struct AppState {
 
 impl AppState {
     pub fn current_buffer<'a>(&'a self) -> &'a Box<dyn Buffer> {
+        if self.prompt.window.focused {
+            return &self.prompt.buffer;
+        }
+
         self.current_window().current_buffer(&self.buffers)
     }
 
     pub fn current_buffer_mut<'a>(&'a mut self) -> &'a mut Box<dyn Buffer> {
+        if self.prompt.window.focused {
+            return &mut self.prompt.buffer;
+        }
+
+        // NOTE: if we just use self.current_window(), rust complains that we've already immutably
+        // borrowed self.buffers, so we go the long way:
         self.tabpages
             .current_tab()
             .current_window()
@@ -33,10 +43,16 @@ impl AppState {
     }
 
     pub fn current_window<'a>(&'a self) -> &'a Box<Window> {
+        if self.prompt.window.focused {
+            return &self.prompt.window;
+        }
         self.current_tab().current_window()
     }
 
     pub fn current_window_mut<'a>(&'a mut self) -> &'a mut Box<Window> {
+        if self.prompt.window.focused {
+            return &mut self.prompt.window;
+        }
         self.current_tab_mut().current_window_mut()
     }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -10,11 +10,14 @@ use crate::editing::{
     Buffer, Resizable, Size,
 };
 
+use super::prompt::Prompt;
+
 pub struct AppState {
     pub running: bool,
     pub buffers: Buffers,
     pub tabpages: Tabpages,
     pub echo_buffer: Box<dyn Buffer>,
+    pub prompt: Prompt,
 }
 
 impl AppState {
@@ -84,6 +87,7 @@ impl Default for AppState {
             buffers,
             tabpages,
             echo_buffer: Box::new(MemoryBuffer::new(0)),
+            prompt: Prompt::default(),
         };
 
         // create the default tabpage

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -100,7 +100,8 @@ impl Default for AppState {
 
 impl Resizable for AppState {
     fn resize(&mut self, new_size: Size) {
-        self.tabpages.resize(new_size)
+        self.tabpages.resize(new_size);
+        self.prompt.resize(new_size);
     }
 }
 

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -108,6 +108,11 @@ impl Buffer for MemoryBuffer {
     }
 
     fn insert(&mut self, cursor: CursorPosition, mut text: TextLine) {
+        if cursor == (0, 0).into() && self.content.lines.is_empty() {
+            self.content.lines.push(text);
+            return;
+        }
+
         let original = &self.content.lines[cursor.line];
         let mut before = original.subs(0, cursor.col as usize);
         let mut after = original.subs(cursor.col as usize, original.width());
@@ -224,6 +229,13 @@ mod tests {
             buf.append("Take my".into());
             buf.insert((0, 7).into(), " love".into());
             assert_visual_match(buf, "Take my love");
+        }
+
+        #[test]
+        fn into_empty() {
+            let mut buf = MemoryBuffer::new(0);
+            buf.insert((0, 0).into(), "serenity".into());
+            assert_visual_match(buf, "serenity");
         }
     }
 }

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -5,7 +5,7 @@ use std::fmt;
 
 use super::{
     motion::MotionRange,
-    text::{TextLine, TextLines},
+    text::{EditableLine, TextLine, TextLines},
     CursorPosition, HasId,
 };
 
@@ -25,6 +25,17 @@ pub trait Buffer: HasId + Send + Sync {
         } else {
             None
         }
+    }
+
+    fn get_contents(&self) -> String {
+        let mut s = String::default();
+        for i in 0..self.lines_count() {
+            if i > 0 {
+                s.push_str("\n");
+            }
+            s.push_str(self.get(i).to_string().as_str());
+        }
+        return s;
     }
 
     fn is_empty(&self) -> bool {

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -10,7 +10,7 @@ pub mod window;
 
 pub use buffer::Buffer;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct Size {
     pub w: u16,
     pub h: u16,

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -76,7 +76,10 @@ pub trait Motion {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::editing::{buffer::MemoryBuffer, text::TextLines, window::Window, Buffer, HasId};
+    use crate::{
+        editing::{buffer::MemoryBuffer, text::TextLines, window::Window, Buffer, HasId},
+        tui::{Display, RenderContext, Renderable},
+    };
 
     use super::*;
 
@@ -97,6 +100,12 @@ pub mod tests {
         pub fn assert_visual_match(&self, s: &'static str) {
             let win = window(s);
             assert_eq!(self.cursor(), win.cursor());
+        }
+
+        pub fn render(&self, display: &mut Display) {
+            let state = crate::app::State::default();
+            let mut context = RenderContext::new(&state, display).with_buffer(&self.buffer);
+            self.window.render(&mut context);
         }
     }
 

--- a/src/editing/text.rs
+++ b/src/editing/text.rs
@@ -8,12 +8,26 @@ pub type TextLines = Text<'static>;
 pub trait EditableLine {
     fn append(&mut self, other: &mut TextLine);
     fn subs(&self, start: usize, end: usize) -> Self;
+    fn starts_with(&self, s: &String) -> bool;
     fn to_string(&self) -> String;
 }
 
 impl EditableLine for TextLine {
     fn append(&mut self, other: &mut TextLine) {
         self.0.append(&mut other.0);
+    }
+
+    fn starts_with(&self, s: &String) -> bool {
+        let mut index = 0;
+        for span in &self.0 {
+            if span.content != s[index..] {
+                return false;
+            }
+
+            index += span.content.len();
+        }
+
+        return true;
     }
 
     fn subs(&self, start: usize, end: usize) -> TextLine {

--- a/src/editing/text.rs
+++ b/src/editing/text.rs
@@ -20,8 +20,15 @@ impl EditableLine for TextLine {
     fn starts_with(&self, s: &String) -> bool {
         let mut index = 0;
         for span in &self.0 {
-            if span.content != s[index..] {
-                return false;
+            for i in 0..span.content.len() {
+                let desti = index + i;
+                if desti >= s.len() {
+                    return true;
+                }
+
+                if span.content[i..i + 1] != s[desti..desti + 1] {
+                    return false;
+                }
             }
 
             index += span.content.len();
@@ -105,6 +112,36 @@ mod tests {
             span.append(&mut part2);
             span.append(&mut part3);
             assert_eq!(span.subs(3, 10).to_string(), "e my lo");
+        }
+    }
+
+    #[cfg(test)]
+    mod starts_with {
+        use super::*;
+
+        #[test]
+        fn single_span() {
+            let s: String = "serenity".into();
+            let part1: TextLine = s.clone().into();
+            assert_eq!(part1.starts_with(&s), true);
+        }
+
+        #[test]
+        fn multi_span_equal_len() {
+            let expected: String = "serenity".into();
+            let mut line: TextLine = "sere".into();
+            let mut part2: TextLine = "nity".into();
+            line.append(&mut part2);
+            assert_eq!(line.starts_with(&expected), true);
+        }
+
+        #[test]
+        fn multi_span_shorter() {
+            let expected: String = "se".into();
+            let mut line: TextLine = "sere".into();
+            let mut part2: TextLine = "nity".into();
+            line.append(&mut part2);
+            assert_eq!(line.starts_with(&expected), true);
         }
     }
 }

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -29,7 +29,7 @@ impl<'a, T> KeySource for KeyHandlerContext<'a, T> {
 }
 
 pub type KeyResult = Result<(), KeyError>;
-pub type KeyHandler<'a, T> = dyn Fn(KeyHandlerContext<'a, T>) -> KeyResult;
+pub type KeyHandler<T> = dyn Fn(KeyHandlerContext<'_, T>) -> KeyResult;
 
 /// Syntactic sugar for declaring a key handler
 #[macro_export]

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -43,6 +43,15 @@ macro_rules! key_handler {
         )
     }};
 
+    ($state_type:ident move |$ctx_name:ident| $body:expr) => {{
+        Box::new(
+            move |mut $ctx_name: crate::input::maps::KeyHandlerContext<$state_type>| {
+                let result: crate::input::maps::KeyResult = $body;
+                result
+            },
+        )
+    }};
+
     ($state_type:ident |?mut $ctx_name:ident| $body:expr) => {{
         Box::new(
             |$ctx_name: crate::input::maps::KeyHandlerContext<$state_type>| {

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -7,7 +7,7 @@ use crate::editing::motion::{
 use crate::input::{KeyCode, KeymapContext};
 use crate::{key_handler, vim_tree};
 
-pub fn vim_insert_mappings<'a>() -> KeyTreeNode<'a> {
+pub fn vim_insert_mappings() -> KeyTreeNode {
     vim_tree! {
         "<a-bs>" => |ctx| {
             let state = ctx.state_mut();
@@ -24,7 +24,7 @@ pub fn vim_insert_mappings<'a>() -> KeyTreeNode<'a> {
     }
 }
 
-pub fn vim_insert_mode<'a>() -> VimMode<'a> {
+pub fn vim_insert_mode() -> VimMode {
     let mappings = vim_tree! {
         "<esc>" => |ctx| {
             ctx.state_mut().clear_echo();

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -34,19 +34,15 @@ pub fn vim_insert_mode() -> VimMode {
          },
     } + vim_insert_mappings();
 
-    VimMode {
-        id: "i".to_string(),
-        mappings,
-        default_handler: Some(key_handler!(
-            VimKeymapState | ctx | {
-                match ctx.key.code {
-                    KeyCode::Char(c) => {
-                        ctx.state_mut().type_at_cursor(c);
-                    }
-                    _ => {} // ignore
-                };
-                Ok(())
-            }
-        )),
-    }
+    VimMode::new("i", mappings).on_default(key_handler!(
+        VimKeymapState | ctx | {
+            match ctx.key.code {
+                KeyCode::Char(c) => {
+                    ctx.state_mut().type_at_cursor(c);
+                }
+                _ => {} // ignore
+            };
+            Ok(())
+        }
+    ))
 }

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -1,21 +1,14 @@
-use super::{VimKeymapState, VimMode};
+use super::{tree::KeyTreeNode, VimKeymapState, VimMode};
 use crate::editing::motion::{
     char::CharMotion,
     word::{is_small_word_boundary, WordMotion},
     Motion,
 };
 use crate::input::{KeyCode, KeymapContext};
-use crate::{key_handler, vim_branches, vim_tree};
+use crate::{key_handler, vim_tree};
 
-pub fn vim_insert_mode<'a>() -> VimMode<'a> {
-    let mappings = vim_tree! {
-        "<esc>" => |ctx| {
-            ctx.state_mut().clear_echo();
-            ctx.state_mut().current_window_mut().set_inserting(false);
-            CharMotion::Backward(1).apply_cursor(ctx.state_mut());
-            Ok(())
-         },
-
+pub fn vim_insert_mappings<'a>() -> KeyTreeNode<'a> {
+    vim_tree! {
         "<a-bs>" => |ctx| {
             let state = ctx.state_mut();
             let motion = WordMotion::backward_until(is_small_word_boundary);
@@ -28,7 +21,18 @@ pub fn vim_insert_mode<'a>() -> VimMode<'a> {
             ctx.state_mut().backspace();
             Ok(())
         },
-    };
+    }
+}
+
+pub fn vim_insert_mode<'a>() -> VimMode<'a> {
+    let mappings = vim_tree! {
+        "<esc>" => |ctx| {
+            ctx.state_mut().clear_echo();
+            ctx.state_mut().current_window_mut().set_inserting(false);
+            CharMotion::Backward(1).apply_cursor(ctx.state_mut());
+            Ok(())
+         },
+    } + vim_insert_mappings();
 
     VimMode {
         mappings,

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -35,6 +35,7 @@ pub fn vim_insert_mode() -> VimMode {
     } + vim_insert_mappings();
 
     VimMode {
+        id: "i".to_string(),
         mappings,
         default_handler: Some(key_handler!(
             VimKeymapState | ctx | {

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -29,6 +29,7 @@ pub struct VimMode<'a> {
 pub struct VimKeymapState {
     pub pending_linewise_operator_key: Option<Key>,
     pub operator_fn: Option<Box<OperatorFn>>,
+    mode_stack: Vec<VimMode<'static>>,
 }
 
 impl Default for VimKeymapState {
@@ -36,11 +37,16 @@ impl Default for VimKeymapState {
         Self {
             pending_linewise_operator_key: None,
             operator_fn: None,
+            mode_stack: Vec::default(),
         }
     }
 }
 
 impl VimKeymapState {
+    pub fn push_mode(&mut self) {
+        // TODO
+    }
+
     fn reset(&mut self) {
         self.pending_linewise_operator_key = None;
         self.operator_fn = None;
@@ -122,6 +128,17 @@ macro_rules! vim_branches {
         $($tail:tt)*
     ) => {
         $root.insert(&$keys.into_keys(), key_handler!(VimKeymapState |$ctx_name| $body));
+        vim_branches! { $root -> $($tail)* }
+    };
+
+    // immutable normal keymap (for completeness):
+    (
+        $root:ident ->
+        $keys:literal =>
+            |?mut $ctx_name:ident| $body:expr,
+        $($tail:tt)*
+    ) => {
+        $root.insert(&$keys.into_keys(), key_handler!(VimKeymapState |?mut $ctx_name| $body));
         vim_branches! { $root -> $($tail)* }
     };
 

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -151,11 +151,13 @@ impl Keymap for VimKeymap {
         }
 
         if let Some(handler) = &mode.after_handler {
-            handler(KeyHandlerContext {
-                context: Box::new(context),
-                keymap: &mut self.keymap,
-                key: '\0'.into(),
-            })?;
+            if self.keymap.mode_stack.contains(&mode.id) {
+                handler(KeyHandlerContext {
+                    context: Box::new(context),
+                    keymap: &mut self.keymap,
+                    key: '\0'.into(),
+                })?;
+            }
         }
 
         if mode_from_stack {

--- a/src/input/maps/vim/mode_stack.rs
+++ b/src/input/maps/vim/mode_stack.rs
@@ -1,0 +1,48 @@
+use std::collections::HashMap;
+
+use super::VimMode;
+
+/// A possibly-overengineered abstraction for managing a stack
+/// of possibly-custom Modes
+pub struct VimModeStack {
+    modes: HashMap<String, VimMode>,
+    stack: Vec<String>,
+}
+
+impl Default for VimModeStack {
+    fn default() -> Self {
+        Self {
+            modes: HashMap::default(),
+            stack: Vec::default(),
+        }
+    }
+}
+
+impl VimModeStack {
+    pub fn push(&mut self, new_mode: VimMode) {
+        self.stack.push(new_mode.id.clone());
+        self.modes.insert(new_mode.id.clone(), new_mode);
+    }
+
+    pub fn pop(&mut self) {
+        self.stack.pop();
+    }
+
+    pub fn return_top(&mut self, mode: VimMode) {
+        if self.stack.contains(&mode.id) {
+            self.modes.insert(mode.id.clone(), mode);
+        }
+    }
+
+    pub fn take_top(&mut self) -> Option<VimMode> {
+        if let Some(id) = self.stack.last() {
+            Some(
+                self.modes
+                    .remove(id)
+                    .expect(&format!("Top of stack mode {} not found", id)),
+            )
+        } else {
+            None
+        }
+    }
+}

--- a/src/input/maps/vim/mode_stack.rs
+++ b/src/input/maps/vim/mode_stack.rs
@@ -19,6 +19,10 @@ impl Default for VimModeStack {
 }
 
 impl VimModeStack {
+    pub fn contains(&self, mode_id: &String) -> bool {
+        self.stack.contains(mode_id)
+    }
+
     pub fn push(&mut self, new_mode: VimMode) {
         self.stack.push(new_mode.id.clone());
         self.modes.insert(new_mode.id.clone(), new_mode);

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -9,7 +9,7 @@ use crate::{
 use super::tree::KeyTreeNode;
 
 /// Motions shared across all types of vim navigation
-pub fn vim_standard_motions<'a>() -> KeyTreeNode<'a> {
+pub fn vim_standard_motions() -> KeyTreeNode {
     vim_tree! {
         "b" => motion { WordMotion::backward_until(is_small_word_boundary) },
         "B" => motion { WordMotion::backward_until(is_big_word_boundary) },
@@ -25,7 +25,7 @@ pub fn vim_standard_motions<'a>() -> KeyTreeNode<'a> {
 }
 
 /// Motions that should only be used for linewise vim (IE: not input mode)
-pub fn vim_linewise_motions<'a>() -> KeyTreeNode<'a> {
+pub fn vim_linewise_motions() -> KeyTreeNode {
     vim_tree! {
         "j" => motion { DownLineMotion },
         "k" => motion { UpLineMotion },

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -1,14 +1,12 @@
 use crate::input::KeymapContext;
+use crate::vim_tree;
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::linewise::{DownLineMotion, ToLineEndMotion, ToLineStartMotion, UpLineMotion},
     editing::motion::word::{is_big_word_boundary, is_small_word_boundary, WordMotion},
-    key_handler,
 };
-use crate::{vim_branches, vim_tree};
 
 use super::tree::KeyTreeNode;
-use super::VimKeymapState;
 
 /// Motions shared across all types of vim navigation
 pub fn vim_standard_motions<'a>() -> KeyTreeNode<'a> {

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,15 +1,14 @@
 use crate::input::KeymapContext;
-use crate::vim_branches;
 use crate::vim_tree;
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
     editing::motion::Motion,
-    key_handler,
 };
 
 use super::{
     motions::{vim_linewise_motions, vim_standard_motions},
+    prompt::vim_prompt_mode,
     tree::KeyTreeNode,
     VimKeymapState, VimMode,
 };
@@ -17,12 +16,9 @@ use super::{
 fn cmd_mode_access<'a>() -> KeyTreeNode<'a> {
     vim_tree! {
         ":" => |ctx| {
-            let prompt = &mut ctx.state_mut().prompt;
-            prompt.clear();
-            prompt.buffer.append(":".into());
-            prompt.handle_content_change();
-
-            ctx.keymap.push_mode(); // TODO
+            // TODO cmd handler
+            ctx.state_mut().prompt.activate(":".into());
+            ctx.keymap.push_mode(vim_prompt_mode(":".into()));
             Ok(())
          },
     }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -62,6 +62,7 @@ pub fn vim_normal_mode() -> VimMode {
         + vim_linewise_motions();
 
     VimMode {
+        id: "n".to_string(),
         mappings,
         default_handler: None,
     }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -13,7 +13,7 @@ use super::{
     VimKeymapState, VimMode,
 };
 
-fn cmd_mode_access<'a>() -> KeyTreeNode<'a> {
+fn cmd_mode_access() -> KeyTreeNode {
     vim_tree! {
         ":" => |ctx| {
             // TODO cmd handler
@@ -24,7 +24,7 @@ fn cmd_mode_access<'a>() -> KeyTreeNode<'a> {
     }
 }
 
-pub fn vim_normal_mode<'a>() -> VimMode<'a> {
+pub fn vim_normal_mode() -> VimMode {
     let mappings = vim_tree! {
         "<cr>" => |ctx| {
             ctx.state_mut().running = false;

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -61,9 +61,5 @@ pub fn vim_normal_mode() -> VimMode {
         + vim_standard_motions()
         + vim_linewise_motions();
 
-    VimMode {
-        id: "n".to_string(),
-        mappings,
-        default_handler: None,
-    }
+    VimMode::new("n", mappings)
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -18,6 +18,7 @@ fn cmd_mode_access<'a>() -> KeyTreeNode<'a> {
     vim_tree! {
         ":" => |ctx| {
             let prompt = &mut ctx.state_mut().prompt;
+            prompt.clear();
             prompt.buffer.append(":".into());
             prompt.handle_content_change();
 

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -10,8 +10,22 @@ use crate::{
 
 use super::{
     motions::{vim_linewise_motions, vim_standard_motions},
+    tree::KeyTreeNode,
     VimKeymapState, VimMode,
 };
+
+fn cmd_mode_access<'a>() -> KeyTreeNode<'a> {
+    vim_tree! {
+        ":" => |ctx| {
+            let prompt = &mut ctx.state_mut().prompt;
+            prompt.buffer.append(":".into());
+            prompt.handle_content_change();
+
+            ctx.keymap.push_mode(); // TODO
+            Ok(())
+         },
+    }
+}
 
 pub fn vim_normal_mode<'a>() -> VimMode<'a> {
     let mappings = vim_tree! {
@@ -46,7 +60,8 @@ pub fn vim_normal_mode<'a>() -> VimMode<'a> {
             Ok(())
         },
 
-    } + vim_standard_motions()
+    } + cmd_mode_access()
+        + vim_standard_motions()
         + vim_linewise_motions();
 
     VimMode {

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -1,0 +1,46 @@
+use crate::{
+    input::{KeyCode, KeymapContext},
+    key_handler, vim_tree,
+};
+
+use super::{insert::vim_insert_mappings, tree::KeyTreeNode, VimKeymapState, VimMode};
+
+fn mappings<'a>(prompt: String) -> KeyTreeNode<'a> {
+    let prompt_len = prompt.len();
+    vim_tree! {
+        "<esc>" => |ctx| {
+            ctx.keymap.mode_stack.pop();
+            ctx.state_mut().prompt.clear();
+            Ok(())
+         },
+
+         "<cr>" => move |ctx| {
+             let input = ctx.state().prompt.buffer.to_string()[prompt_len..].to_string();
+             ctx.keymap.mode_stack.pop();
+             ctx.state_mut().prompt.clear();
+
+             // TODO submit to handler
+             ctx.state_mut().current_buffer_mut().append(input.into());
+             Ok(())
+         },
+    }
+}
+
+pub fn vim_prompt_mode<'a>(prompt: String) -> VimMode<'a> {
+    // TODO an "after" handler to ensure we don't delete or move onto the prompt
+    VimMode {
+        mappings: vim_insert_mappings() + mappings(prompt),
+        default_handler: Some(key_handler!(
+            VimKeymapState | ctx | {
+                match ctx.key.code {
+                    KeyCode::Char(c) => {
+                        ctx.state_mut().type_at_cursor(c);
+                    }
+                    _ => {} // ignore
+                };
+
+                Ok(())
+            }
+        )),
+    }
+}

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -15,7 +15,7 @@ fn mappings(prompt: String) -> KeyTreeNode {
          },
 
          "<cr>" => move |ctx| {
-             let input = ctx.state().prompt.buffer.to_string()[prompt_len..].to_string();
+             let input = ctx.state().prompt.buffer.get_contents()[prompt_len..].to_string();
              ctx.keymap.mode_stack.pop();
              ctx.state_mut().prompt.clear();
 

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -29,6 +29,7 @@ fn mappings(prompt: String) -> KeyTreeNode {
 pub fn vim_prompt_mode(prompt: String) -> VimMode {
     // TODO an "after" handler to ensure we don't delete or move onto the prompt
     VimMode {
+        id: format!("prompt:{}", prompt),
         mappings: vim_insert_mappings() + mappings(prompt),
         default_handler: Some(key_handler!(
             VimKeymapState | ctx | {

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -5,7 +5,7 @@ use crate::{
 
 use super::{insert::vim_insert_mappings, tree::KeyTreeNode, VimKeymapState, VimMode};
 
-fn mappings<'a>(prompt: String) -> KeyTreeNode<'a> {
+fn mappings(prompt: String) -> KeyTreeNode {
     let prompt_len = prompt.len();
     vim_tree! {
         "<esc>" => |ctx| {
@@ -26,7 +26,7 @@ fn mappings<'a>(prompt: String) -> KeyTreeNode<'a> {
     }
 }
 
-pub fn vim_prompt_mode<'a>(prompt: String) -> VimMode<'a> {
+pub fn vim_prompt_mode(prompt: String) -> VimMode {
     // TODO an "after" handler to ensure we don't delete or move onto the prompt
     VimMode {
         mappings: vim_insert_mappings() + mappings(prompt),

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -28,8 +28,11 @@ fn mappings(prompt: String) -> KeyTreeNode {
 }
 
 pub fn vim_prompt_mode(prompt: String) -> VimMode {
+    let prompt_len = prompt.len();
+    let mode_id = format!("prompt:{}", prompt);
+
     VimMode::new(
-        format!("prompt:{}", prompt),
+        mode_id.clone(),
         vim_insert_mappings() + mappings(prompt.clone()),
     )
     .on_default(key_handler!(
@@ -49,6 +52,11 @@ pub fn vim_prompt_mode(prompt: String) -> VimMode {
             let b = &ctx.state().prompt.buffer;
             if b.is_empty() || !b.get(0).starts_with(&prompt) {
                 ctx.state_mut().prompt.buffer.insert((0, 0).into(), prompt.clone().into());
+            }
+
+            let cursor = ctx.state().current_window().cursor;
+            if cursor.line == 0 && cursor.col < prompt_len as u16 {
+                ctx.state_mut().current_window_mut().cursor.col = prompt_len as u16;
             }
 
             Ok(())

--- a/src/input/maps/vim/tree.rs
+++ b/src/input/maps/vim/tree.rs
@@ -4,13 +4,13 @@ use crate::input::Key;
 
 use super::KeyHandler;
 
-pub struct KeyTreeNode<'a> {
-    pub children: HashMap<Key, KeyTreeNode<'a>>,
-    handler: Option<Box<KeyHandler<'a>>>,
-    handler_override: Option<Box<KeyHandler<'a>>>,
+pub struct KeyTreeNode {
+    pub children: HashMap<Key, KeyTreeNode>,
+    handler: Option<Box<KeyHandler>>,
+    handler_override: Option<Box<KeyHandler>>,
 }
 
-impl<'a> KeyTreeNode<'a> {
+impl KeyTreeNode {
     pub fn root() -> Self {
         Self {
             children: HashMap::new(),
@@ -19,7 +19,7 @@ impl<'a> KeyTreeNode<'a> {
         }
     }
 
-    pub fn get_handler(&self) -> Option<&Box<KeyHandler<'a>>> {
+    pub fn get_handler(&self) -> Option<&Box<KeyHandler>> {
         if let Some(overridden) = &self.handler_override {
             Some(overridden)
         } else if let Some(handler) = &self.handler {
@@ -29,7 +29,7 @@ impl<'a> KeyTreeNode<'a> {
         }
     }
 
-    pub fn insert(&mut self, keys: &[Key], handler: Box<KeyHandler<'a>>) {
+    pub fn insert(&mut self, keys: &[Key], handler: Box<KeyHandler>) {
         if keys.is_empty() {
             self.handler = Some(handler);
         } else {
@@ -43,10 +43,10 @@ impl<'a> KeyTreeNode<'a> {
     }
 }
 
-impl<'a> ops::Add<KeyTreeNode<'a>> for KeyTreeNode<'a> {
-    type Output = KeyTreeNode<'a>;
+impl ops::Add<KeyTreeNode> for KeyTreeNode {
+    type Output = KeyTreeNode;
 
-    fn add(self, mut rhs: KeyTreeNode<'a>) -> Self::Output {
+    fn add(self, mut rhs: KeyTreeNode) -> Self::Output {
         let mut result = KeyTreeNode::root();
 
         if let Some(rhs_handler) = rhs.handler {

--- a/src/tui/measure/mod.rs
+++ b/src/tui/measure/mod.rs
@@ -60,6 +60,12 @@ impl Measurable for TextLines {
     }
 }
 
+impl Measurable for Vec<&TextLine> {
+    fn measure_height(&self, width: u16) -> u16 {
+        self.iter().map(|line| line.measure_height(width)).sum()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/measure/mod.rs
+++ b/src/tui/measure/mod.rs
@@ -66,6 +66,13 @@ impl Measurable for Vec<&TextLine> {
     }
 }
 
+impl Measurable for dyn crate::editing::buffer::Buffer {
+    fn measure_height(&self, width: u16) -> u16 {
+        let lines: Vec<&TextLine> = (0..self.lines_count()).map(|i| self.get(i)).collect();
+        lines.measure_height(width)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -123,6 +123,10 @@ impl Tui {
             &mut RenderContext::new(app, &mut prompt_display).with_buffer(&app.prompt.buffer),
         );
 
+        if app.prompt.window.focused {
+            display.cursor = prompt_display.cursor.clone();
+        }
+
         display.shift_up(prompt_height - 1);
         display.merge_at_y(display.size.h - prompt_height, prompt_display);
     }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -4,8 +4,8 @@ use crate::{
 };
 
 use crossterm::terminal;
-use editing::{window::Window, Buffer};
-use std::io;
+use editing::window::Window;
+use std::{cmp::min, io};
 pub use tui::text;
 use tui::{backend::Backend, Terminal};
 use tui::{backend::CrosstermBackend, layout::Rect};
@@ -14,6 +14,7 @@ pub mod cursor;
 pub mod events;
 pub mod layout;
 pub mod measure;
+pub mod rendering;
 pub mod tabpage;
 pub mod tabpages;
 pub mod window;
@@ -21,90 +22,10 @@ pub mod window;
 use cursor::CursorRenderer;
 use measure::Measurable;
 
-pub struct Display {
-    pub size: Size,
-    pub buffer: tui::buffer::Buffer,
-    pub cursor: editing::Cursor,
-}
-
-impl Display {
-    pub fn new(size: Size) -> Self {
-        Self {
-            size,
-            buffer: tui::buffer::Buffer::empty(size.into()),
-            cursor: editing::Cursor::None,
-        }
-    }
-
-    pub fn set_cursor(&mut self, cursor: editing::Cursor) {
-        self.cursor = cursor;
-    }
-}
-
-impl tui::widgets::Widget for Display {
-    fn render(self, _area: Rect, buf: &mut tui::buffer::Buffer) {
-        buf.merge(&self.buffer);
-    }
-}
-
-impl std::fmt::Display for Display {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[Display({:?})", self.size)?;
-
-        // TODO copy content
-        // for line in &self.lines {
-        //     write!(f, "\n  {:?}", line)?;
-        // }
-
-        write!(f, "]")
-    }
-}
-
-impl Into<Rect> for Size {
-    fn into(self) -> Rect {
-        Rect::new(0, 0, self.w, self.h)
-    }
-}
-
-impl From<Rect> for Size {
-    fn from(rect: Rect) -> Self {
-        Self {
-            w: rect.width,
-            h: rect.height,
-        }
-    }
-}
-
-impl From<(u16, u16)> for Size {
-    fn from(size: (u16, u16)) -> Self {
-        Self {
-            w: size.0,
-            h: size.1,
-        }
-    }
-}
-
-pub struct RenderContext<'a> {
-    app: &'a crate::app::State,
-    display: &'a mut Display,
-    area: Rect,
-    buffer_override: Option<&'a Box<dyn Buffer>>,
-}
-
-impl<'a> RenderContext<'a> {
-    pub fn with_area(&mut self, new_area: Rect) -> RenderContext {
-        RenderContext {
-            app: self.app,
-            display: self.display,
-            area: new_area,
-            buffer_override: self.buffer_override,
-        }
-    }
-}
-
-pub trait Renderable {
-    fn render(&self, app: &mut RenderContext);
-}
+pub use rendering::context::RenderContext;
+pub use rendering::display::Display;
+pub use rendering::size;
+pub use rendering::Renderable;
 
 pub struct Tui {
     terminal: Terminal<CrosstermBackend<io::Stdout>>,
@@ -153,6 +74,9 @@ impl Tui {
         };
         app.tabpages.render(&mut context);
 
+        // prompt
+        self.render_prompt(app, &mut display);
+
         self.render_display(display)
     }
 
@@ -182,6 +106,24 @@ impl Tui {
             h: echo_height,
         });
         win.render(&mut context);
+    }
+
+    fn render_prompt(&mut self, app: &mut crate::app::State, display: &mut Display) {
+        let mut prompt_display = Display::new(display.size);
+        app.prompt.window.render(
+            &mut RenderContext::new(app, &mut prompt_display).with_buffer(&app.prompt.buffer),
+        );
+        let prompt_height = min(
+            display.size.h,
+            app.prompt.buffer.measure_height(display.size.w),
+        );
+        if prompt_height == 0 {
+            // nop
+            return;
+        }
+
+        display.shift_up(prompt_height.checked_sub(1).unwrap_or(0));
+        display.merge_at_y(display.size.h - prompt_height, prompt_display);
     }
 
     fn render_display(&mut self, display: Display) -> Result<(), io::Error> {

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -109,10 +109,6 @@ impl Tui {
     }
 
     fn render_prompt(&mut self, app: &mut crate::app::State, display: &mut Display) {
-        let mut prompt_display = Display::new(display.size);
-        app.prompt.window.render(
-            &mut RenderContext::new(app, &mut prompt_display).with_buffer(&app.prompt.buffer),
-        );
         let prompt_height = min(
             display.size.h,
             app.prompt.buffer.measure_height(display.size.w),
@@ -122,7 +118,12 @@ impl Tui {
             return;
         }
 
-        display.shift_up(prompt_height.checked_sub(1).unwrap_or(0));
+        let mut prompt_display = Display::new(display.size);
+        app.prompt.window.render(
+            &mut RenderContext::new(app, &mut prompt_display).with_buffer(&app.prompt.buffer),
+        );
+
+        display.shift_up(prompt_height - 1);
         display.merge_at_y(display.size.h - prompt_height, prompt_display);
     }
 

--- a/src/tui/rendering/context.rs
+++ b/src/tui/rendering/context.rs
@@ -1,0 +1,40 @@
+use tui::layout::Rect;
+
+use crate::{editing::Buffer, tui::Display};
+
+pub struct RenderContext<'a> {
+    pub app: &'a crate::app::State,
+    pub display: &'a mut Display,
+    pub area: Rect,
+    pub buffer_override: Option<&'a Box<dyn Buffer>>,
+}
+
+impl<'a> RenderContext<'a> {
+    pub fn new(app: &'a crate::app::State, display: &'a mut Display) -> Self {
+        let area = display.size.into();
+        Self {
+            app,
+            display,
+            area,
+            buffer_override: None,
+        }
+    }
+
+    pub fn with_buffer(self, buffer_override: &'a Box<dyn Buffer>) -> Self {
+        Self {
+            app: self.app,
+            display: self.display,
+            area: self.area,
+            buffer_override: Some(buffer_override),
+        }
+    }
+
+    pub fn with_area(&mut self, new_area: Rect) -> RenderContext {
+        RenderContext {
+            app: self.app,
+            display: self.display,
+            area: new_area,
+            buffer_override: self.buffer_override,
+        }
+    }
+}

--- a/src/tui/rendering/display.rs
+++ b/src/tui/rendering/display.rs
@@ -1,0 +1,73 @@
+use tui::layout::Rect;
+
+use crate::editing::{self, Size};
+
+pub struct Display {
+    pub size: Size,
+    pub buffer: tui::buffer::Buffer,
+    pub cursor: editing::Cursor,
+}
+
+impl Display {
+    pub fn new(size: Size) -> Self {
+        Self {
+            size,
+            buffer: tui::buffer::Buffer::empty(size.into()),
+            cursor: editing::Cursor::None,
+        }
+    }
+
+    pub fn merge_at_y(&mut self, y: u16, other: Display) {
+        let to_merge_height = self.size.h - y;
+        let cells_start = (y * self.size.w) as usize;
+        let cells_count = (to_merge_height * self.size.w) as usize;
+        let mut cells = other
+            .buffer
+            .content()
+            .iter()
+            .skip(cells_start)
+            .take(cells_count);
+
+        let start = self.buffer.index_of(0, y);
+        for i in start..self.buffer.content.len() {
+            if let Some(cell) = cells.next() {
+                self.buffer.content[i] = cell.to_owned();
+            } else {
+                // no more cells to merge
+                break;
+            }
+        }
+    }
+
+    pub fn shift_up(&mut self, lines: u16) {
+        if lines == 0 {
+            return; // nop
+        }
+
+        self.buffer.content.drain(0..(lines * self.size.w) as usize);
+        self.buffer.resize(self.size.into());
+    }
+
+    pub fn set_cursor(&mut self, cursor: editing::Cursor) {
+        self.cursor = cursor;
+    }
+}
+
+impl tui::widgets::Widget for Display {
+    fn render(self, _area: Rect, buf: &mut tui::buffer::Buffer) {
+        buf.merge(&self.buffer);
+    }
+}
+
+impl std::fmt::Display for Display {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "[Display({:?})", self.size)?;
+
+        // TODO copy content
+        // for line in &self.lines {
+        //     write!(f, "\n  {:?}", line)?;
+        // }
+
+        write!(f, "]")
+    }
+}

--- a/src/tui/rendering/display.rs
+++ b/src/tui/rendering/display.rs
@@ -18,6 +18,13 @@ impl Display {
     }
 
     pub fn merge_at_y(&mut self, y: u16, other: Display) {
+        if other.size != self.size {
+            panic!(
+                "other.size({:?}) does not match self.size({:?})",
+                other.size, self.size
+            );
+        }
+
         let to_merge_height = self.size.h - y;
         let cells_start = (y * self.size.w) as usize;
         let cells_count = (to_merge_height * self.size.w) as usize;
@@ -88,7 +95,7 @@ mod tests {
 
     impl TestableDisplay for Display {
         fn of_string(s: &'static str) -> Display {
-            let width = s.find('\n').unwrap_or(s.len());
+            let width = s.split('\n').map(|l| l.len()).max().unwrap_or(s.len());
             let height = s.chars().filter(|ch| *ch == '\n').count();
 
             let mut display = Display::new(Size {
@@ -165,6 +172,25 @@ mod tests {
         display.assert_visual_match(indoc! {"
             Take my land
 
+        "});
+    }
+
+    #[test]
+    fn merge_at_y_works() {
+        let mut display = Display::of_string(indoc! {"
+            Take my love
+
+        "});
+
+        let to_merge = Display::of_string(indoc! {"
+            _
+            Take my land
+        "});
+        display.merge_at_y(1, to_merge);
+
+        display.assert_visual_match(indoc! {"
+            Take my love
+            Take my land
         "});
     }
 }

--- a/src/tui/rendering/mod.rs
+++ b/src/tui/rendering/mod.rs
@@ -1,0 +1,7 @@
+pub mod context;
+pub mod display;
+pub mod size;
+
+pub trait Renderable {
+    fn render(&self, app: &mut context::RenderContext);
+}

--- a/src/tui/rendering/size.rs
+++ b/src/tui/rendering/size.rs
@@ -1,0 +1,27 @@
+use tui::layout::Rect;
+
+use crate::editing::Size;
+
+impl Into<Rect> for Size {
+    fn into(self) -> Rect {
+        Rect::new(0, 0, self.w, self.h)
+    }
+}
+
+impl From<Rect> for Size {
+    fn from(rect: Rect) -> Self {
+        Self {
+            w: rect.width,
+            h: rect.height,
+        }
+    }
+}
+
+impl From<(u16, u16)> for Size {
+    fn from(size: (u16, u16)) -> Self {
+        Self {
+            w: size.0,
+            h: size.1,
+        }
+    }
+}


### PR DESCRIPTION
- Prepare to support a "prompt" window for handling cmdline mode, etc
- Enable Buffer to measure its height
- Reorganize TUI rendering code; prepare vertical shifting for prompt
- Support visual rendering tests; Add simple Display.shift_up() test
- Add merge_at_y test + handle incomplete lines in Display::of_string
- Don't try to render prompt until it has content
- Add convenience to clear the prompt
- Actually resize the prompt as appropriate
- Prepare "prompt mode"
- Elide lifetimes on VimMode et al to use mode_stack; improve activation
- Implement our ModeStack idea---we no longer get stuck in prompt()
- Use prompt window's cursor if focused
- Extract prompt buffer contents properly
