### PR TITLE
Add basic edit/write commands + BufferSource

### DIFF
--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -32,6 +32,9 @@ impl Buffer for MemoryBuffer {
     fn source(&self) -> &BufferSource {
         &self.source
     }
+    fn set_source(&mut self, source: BufferSource) {
+        self.source = source;
+    }
 
     fn lines_count(&self) -> usize {
         self.content.height()
@@ -154,6 +157,7 @@ mod tests {
         let expected = MemoryBuffer {
             id: 0,
             content: s.into(),
+            source: BufferSource::None,
         }
         .to_string();
 

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -1,5 +1,6 @@
 use crate::editing::{
     motion::MotionRange,
+    source::BufferSource,
     text::EditableLine,
     text::{TextLine, TextLines},
     Buffer, CursorPosition, HasId,
@@ -8,6 +9,7 @@ use crate::editing::{
 pub struct MemoryBuffer {
     id: usize,
     content: TextLines,
+    pub source: BufferSource,
 }
 
 impl MemoryBuffer {
@@ -15,6 +17,7 @@ impl MemoryBuffer {
         MemoryBuffer {
             id,
             content: TextLines::default(),
+            source: BufferSource::None,
         }
     }
 }
@@ -26,6 +29,10 @@ impl HasId for MemoryBuffer {
 }
 
 impl Buffer for MemoryBuffer {
+    fn source(&self) -> &BufferSource {
+        &self.source
+    }
+
     fn lines_count(&self) -> usize {
         self.content.height()
     }

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -14,6 +14,7 @@ use super::{
 
 pub trait Buffer: HasId + Send + Sync {
     fn source(&self) -> &BufferSource;
+    fn set_source(&mut self, source: BufferSource);
     fn is_read_only(&self) -> bool {
         match self.source() {
             BufferSource::Connection(_) => true,

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -7,11 +7,20 @@ use crate::input::completion::Completion;
 
 use super::{
     motion::MotionRange,
+    source::BufferSource,
     text::{EditableLine, TextLine, TextLines},
     CursorPosition, HasId,
 };
 
 pub trait Buffer: HasId + Send + Sync {
+    fn source(&self) -> &BufferSource;
+    fn is_read_only(&self) -> bool {
+        match self.source() {
+            BufferSource::Connection(_) => true,
+            _ => false,
+        }
+    }
+
     fn lines_count(&self) -> usize;
     fn append(&mut self, text: TextLines);
     fn clear(&mut self);

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -3,6 +3,7 @@ pub mod buffers;
 pub mod ids;
 pub mod layout;
 pub mod motion;
+pub mod source;
 pub mod tabpage;
 pub mod tabpages;
 pub mod text;

--- a/src/editing/source/mod.rs
+++ b/src/editing/source/mod.rs
@@ -10,3 +10,12 @@ pub enum BufferSource {
     /// buffers MUST be read-only
     Connection(String),
 }
+
+impl BufferSource {
+    pub fn is_none(&self) -> bool {
+        match self {
+            &BufferSource::None => true,
+            _ => false,
+        }
+    }
+}

--- a/src/editing/source/mod.rs
+++ b/src/editing/source/mod.rs
@@ -1,0 +1,12 @@
+pub enum BufferSource {
+    /// The Buffer is in-memory only
+    None,
+
+    /// The Buffer was read from or has been written to a file
+    /// on disk with the given absolute path
+    LocalFile(String),
+
+    /// The Buffer receives its content from a network source; such
+    /// buffers MUST be read-only
+    Connection(String),
+}

--- a/src/input/commands/file.rs
+++ b/src/input/commands/file.rs
@@ -2,13 +2,51 @@
  * File IO commands
  */
 
+use crate::{
+    editing::{
+        source::BufferSource,
+        text::{TextLine, TextLines},
+    },
+    input::KeyError,
+};
+use std::fs;
+
 use crate::{declare_commands, input::KeymapContext};
 
 declare_commands!(declare_file {
     pub fn edit(context, file_path: String) {
-        // TODO find an existing buffer, or read into a new one and
-        // update our window
-        context.state_mut().echo(format!("{}: TODO: read", file_path).into());
+        // TODO actually, if the buffer is saved or open in another window,
+        // we should be allowed to replace it.
+        let current_source = context.state().current_buffer().source();
+        match current_source {
+            &BufferSource::Connection(_) => {
+                return Err(KeyError::NotPermitted("Cannot replace Connection buffer".to_string()));
+            },
+            &BufferSource::LocalFile(_) => return Err(KeyError::NotPermitted("Buffer backed by a file".to_string())),
+            &BufferSource::None => {}, // continue
+        };
+
+        // TODO if the file doesn't exist, we should still be able to edit it
+        let full_path = fs::canonicalize(&file_path)?;
+        let contents = fs::read_to_string(&full_path)?;
+        let bytes = contents.as_bytes().len();
+        let lines: Vec<TextLine> = contents.split("\n").map(|line| line.to_owned().into()).collect();
+        let lines_count = lines.len();
+
+        let full_path_string = full_path.to_string_lossy();
+        context.state_mut().echo(format!("\"{}\": {}L, {}B", full_path_string, lines_count, bytes).into());
+
+        let buffer_id = {
+            let buffer = context.state_mut().buffers.create();
+            buffer.id()
+        };
+
+        let buf = context.state_mut().buffers.by_id_mut(buffer_id).expect("New buffer did not exist");
+        buf.append(TextLines::from(lines));
+        buf.set_source(BufferSource::LocalFile(full_path_string.to_string()));
+
+        context.state_mut().current_window_mut().buffer = buffer_id;
+
         Ok(())
     },
 });

--- a/src/input/commands/file.rs
+++ b/src/input/commands/file.rs
@@ -1,0 +1,14 @@
+/*!
+ * File IO commands
+ */
+
+use crate::{declare_commands, input::KeymapContext};
+
+declare_commands!(declare_file {
+    pub fn edit(context, file_path: String) {
+        // TODO find an existing buffer, or read into a new one and
+        // update our window
+        context.state_mut().echo(format!("{}: TODO: read", file_path).into());
+        Ok(())
+    },
+});

--- a/src/input/commands/mod.rs
+++ b/src/input/commands/mod.rs
@@ -1,9 +1,10 @@
 pub mod core;
+pub mod file;
 pub mod registry;
 
 use std::time::Duration;
 
-use self::{core::declare_core, registry::CommandRegistry};
+use self::{core::declare_core, file::declare_file, registry::CommandRegistry};
 
 use super::{maps::KeyResult, Key, KeyError, KeySource, KeymapContext};
 
@@ -20,6 +21,29 @@ impl<'a> CommandHandlerContext<'a> {
             context: Box::new(context),
             input,
         }
+    }
+}
+
+impl CommandHandlerContext<'_> {
+    pub fn args(&self) -> Vec<&str> {
+        self.split_input().skip(1).collect()
+    }
+
+    pub fn command(&self) -> Option<&str> {
+        if let Some(cmd) = self.split_input().next() {
+            if cmd.is_empty() {
+                None
+            } else {
+                Some(cmd)
+            }
+        } else {
+            None
+        }
+    }
+
+    fn split_input(&self) -> impl Iterator<Item = &str> {
+        // TODO handle quoted input
+        self.input.split(" ")
     }
 }
 
@@ -44,5 +68,6 @@ impl KeySource for CommandHandlerContext<'_> {
 pub fn create_builtin_commands() -> CommandRegistry {
     let mut registry = CommandRegistry::default();
     declare_core(&mut registry);
+    declare_file(&mut registry);
     return registry;
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -14,16 +14,20 @@ use super::{
 };
 
 fn handle_command(mut context: &mut CommandHandlerContext) -> KeyResult {
-    let input = context.input.clone();
-    if let Some((name, handler)) = context.state_mut().builtin_commands.take(&input) {
-        let result = handler(&mut context);
-        context
-            .state_mut()
-            .builtin_commands
-            .declare(name, false, handler);
-        result
+    if let Some(command) = context.command().and_then(|s| Some(s.to_string())) {
+        if let Some((name, handler)) = context.state_mut().builtin_commands.take(&command) {
+            let result = handler(&mut context);
+            context
+                .state_mut()
+                .builtin_commands
+                .declare(name, false, handler);
+            result
+        } else {
+            Err(KeyError::NoSuchCommand(command))
+        }
     } else {
-        Err(KeyError::NoSuchCommand(input))
+        // no command; nop is okay
+        Ok(())
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -28,6 +28,7 @@ impl From<KeyCode> for Key {
 #[derive(Debug)]
 pub enum KeyError {
     IO(io::Error),
+    NotPermitted(String),
     InvalidInput(String),
     NoSuchCommand(String),
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -28,6 +28,7 @@ impl From<KeyCode> for Key {
 #[derive(Debug)]
 pub enum KeyError {
     IO(io::Error),
+    InvalidInput(String),
     NoSuchCommand(String),
 }
 


### PR DESCRIPTION
- Prepare preliminary file editing concepts + scaffold edit command
- Implement a very basic `edit` command
- Support writing buffers to disk

BufferSource is kind of like vim's "buffer name," but a bit more prescriptive, since some of our buffers should always be read-only due to how their content will be provided.

This is exciting because we can actually open notes files in split windows, for example!
