### PR TITLE
Add ConnLayout, a special Window-pair layout for Connections

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -104,12 +104,6 @@ impl AppState {
         None
     }
 
-    pub fn current_winsbuf<'a>(&'a mut self) -> WinsBuf<'a> {
-        self.winsbuf_by_id(self.current_buffer().id())
-            .expect("No current buffer!?")
-    }
-
-    /// Unlike BufWin, this will NEVER operate on the prompt window/buffer
     pub fn winsbuf_by_id<'a>(&'a mut self, buffer_id: Id) -> Option<WinsBuf<'a>> {
         if let Some(buffer) = self.buffers.by_id_mut(buffer_id) {
             let windows = self.tabpages.windows_for_buffer(buffer_id);

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -12,6 +12,8 @@ use crate::{
 
 use super::{Connection, ConnectionFactories};
 
+const DEFAULT_LINES_PER_REDRAW: u16 = 10;
+
 pub struct Connections {
     ids: Ids,
     all: Vec<Box<dyn Connection>>,
@@ -96,12 +98,17 @@ impl Connections {
     pub fn process(&mut self, app: &mut app::State) -> bool {
         let to_buffer = &mut self.connection_to_buffer;
         let mut any_updated = false;
-        let lines_per_redraw = app.current_window().size.h;
         retain(&mut self.all, |conn| {
             let buffer_id = to_buffer[&conn.id()];
             let mut winsbuf = app
                 .winsbuf_by_id(buffer_id)
                 .expect("Could not find buffer for connection");
+            let lines_per_redraw = winsbuf
+                .windows
+                .iter()
+                .map(|win| win.size.h)
+                .max()
+                .unwrap_or(DEFAULT_LINES_PER_REDRAW);
 
             for _ in 0..lines_per_redraw {
                 match conn.read() {

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -40,12 +40,20 @@ impl Default for Connections {
 }
 
 impl Connections {
-    pub fn by_id(&self, id: Id) -> Option<&Box<dyn Connection>> {
-        self.all.iter().find(|conn| conn.id() == id)
-    }
-
     pub fn by_id_mut(&mut self, id: Id) -> Option<&mut Box<dyn Connection>> {
         self.all.iter_mut().find(|conn| conn.id() == id)
+    }
+
+    pub fn buffer_to_id(&mut self, buffer_id: Id) -> Option<Id> {
+        self.buffer_to_connection.get(&buffer_id).cloned()
+    }
+
+    pub fn by_buffer_id(&mut self, buffer_id: Id) -> Option<&mut Box<dyn Connection>> {
+        if let Some(conn_id) = self.buffer_to_id(buffer_id) {
+            self.by_id_mut(conn_id)
+        } else {
+            None
+        }
     }
 
     /// Asynchronously create a new connection attached to the given

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -19,6 +19,11 @@ pub enum ReadValue {
 pub trait Connection: Send {
     fn id(&self) -> Id;
     fn read(&mut self) -> io::Result<Option<ReadValue>>;
+    fn write(&mut self, bytes: &[u8]) -> io::Result<()>;
+    fn send(&mut self, text: String) -> io::Result<()> {
+        self.write(text.as_bytes())?;
+        self.write(&vec!['\n' as u8])
+    }
 }
 
 pub trait ConnectionFactory: Send + Sync {

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -26,7 +26,8 @@ impl Connection for TelnetConnection {
     fn id(&self) -> Id {
         self.id
     }
-    fn read(&mut self) -> std::io::Result<Option<ReadValue>> {
+
+    fn read(&mut self) -> io::Result<Option<ReadValue>> {
         match self.telnet.read_nonblocking()? {
             telnet::TelnetEvent::Data(data) => {
                 self.pipeline.feed(&data, data.len());
@@ -42,6 +43,11 @@ impl Connection for TelnetConnection {
         }
         // always attempt to pull ReadValues out of the pipeline
         return Ok(self.pipeline.next());
+    }
+
+    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.telnet.write(bytes)?;
+        Ok(())
     }
 }
 

--- a/src/editing/buffers.rs
+++ b/src/editing/buffers.rs
@@ -33,6 +33,16 @@ impl Buffers {
 
         self.all.last().unwrap()
     }
+
+    pub fn create_mut(&mut self) -> &mut Box<dyn Buffer> {
+        let id = self.ids.next();
+        let buffer = MemoryBuffer::new(id);
+        let boxed = Box::new(buffer);
+
+        self.all.push(boxed);
+
+        self.all.last_mut().unwrap()
+    }
 }
 
 impl fmt::Display for Buffers {

--- a/src/editing/layout/conn.rs
+++ b/src/editing/layout/conn.rs
@@ -1,0 +1,83 @@
+use genawaiter::{sync::gen, yield_};
+
+use crate::editing::{window::Window, FocusDirection, Id, Resizable, Size};
+
+use super::Layout;
+
+pub struct ConnLayout {
+    pub output: Box<Window>,
+    pub input: Box<Window>,
+}
+
+impl Layout for ConnLayout {
+    fn by_id(&self, id: Id) -> Option<&Box<Window>> {
+        if self.output.id == id {
+            Some(&self.output)
+        } else if self.input.id == id {
+            Some(&self.input)
+        } else {
+            None
+        }
+    }
+
+    fn by_id_mut(&mut self, id: Id) -> Option<&mut Box<Window>> {
+        if self.output.id == id {
+            Some(&mut self.output)
+        } else if self.input.id == id {
+            Some(&mut self.input)
+        } else {
+            None
+        }
+    }
+
+    fn windows_for_buffer(
+        &mut self,
+        buffer_id: Id,
+    ) -> Box<dyn Iterator<Item = &mut Box<Window>> + '_> {
+        Box::new(
+            gen!({
+                if self.output.buffer == buffer_id {
+                    yield_!(&mut self.output);
+                } else if self.input.buffer == buffer_id {
+                    yield_!(&mut self.input);
+                }
+            })
+            .into_iter(),
+        )
+    }
+
+    fn next_focus(&self, current_id: Id, direction: FocusDirection) -> Option<Id> {
+        match direction {
+            FocusDirection::Down if current_id == self.output.id => Some(self.input.id),
+            FocusDirection::Up if current_id == self.input.id => Some(self.output.id),
+            _ => None,
+        }
+    }
+
+    fn first_focus(&self, direction: FocusDirection) -> Option<Id> {
+        match direction {
+            FocusDirection::Up | FocusDirection::Left => Some(self.input.id),
+            FocusDirection::Right | FocusDirection::Down => Some(self.output.id),
+        }
+    }
+
+    fn size(&self) -> Size {
+        Size {
+            w: self.output.size.w,
+            h: self.output.size.h + self.input.size.h,
+        }
+    }
+}
+
+impl Resizable for ConnLayout {
+    fn resize(&mut self, new_size: Size) {
+        self.output.resize(Size {
+            w: new_size.w,
+            h: new_size.h - 1,
+        });
+        self.input.resize(Size {
+            w: new_size.w,
+            h: 1,
+        });
+    }
+}

--- a/src/editing/layout/conn.rs
+++ b/src/editing/layout/conn.rs
@@ -30,6 +30,16 @@ impl Layout for ConnLayout {
         }
     }
 
+    fn current_focus(&self) -> Option<Id> {
+        if self.output.focused {
+            Some(self.output.id)
+        } else if self.input.focused {
+            Some(self.input.id)
+        } else {
+            None
+        }
+    }
+
     fn windows_for_buffer(
         &mut self,
         buffer_id: Id,

--- a/src/editing/layout/linear.rs
+++ b/src/editing/layout/linear.rs
@@ -111,6 +111,15 @@ impl Layout for LinearLayout {
         None
     }
 
+    fn current_focus(&self) -> Option<Id> {
+        for entry in &self.entries {
+            if let Some(id) = entry.current_focus() {
+                return Some(id);
+            }
+        }
+        None
+    }
+
     fn windows_for_buffer(
         &mut self,
         buffer_id: Id,

--- a/src/editing/layout/linear.rs
+++ b/src/editing/layout/linear.rs
@@ -47,7 +47,7 @@ impl LinearLayout {
         self.entries.push(Box::new(WinLayout::new(window)))
     }
 
-    fn index_of_window(&mut self, id: Id) -> Option<usize> {
+    fn index_of_window(&self, id: Id) -> Option<usize> {
         self.entries
             .iter()
             .position(|entry| entry.contains_window(id))
@@ -59,7 +59,7 @@ impl LinearLayout {
         f: impl FnOnce(Box<dyn Layout>) -> Box<dyn Layout>,
     ) {
         if let Some(index) = self.index_of_window(win_id) {
-            let mut lyt = self.entries.swap_remove(index);
+            let lyt = self.entries.swap_remove(index);
             self.entries.push(f(lyt));
             if self.entries.len() > 1 {
                 let last = self.entries.len() - 1;

--- a/src/editing/layout/linear.rs
+++ b/src/editing/layout/linear.rs
@@ -47,6 +47,27 @@ impl LinearLayout {
         self.entries.push(Box::new(WinLayout::new(window)))
     }
 
+    fn index_of_window(&mut self, id: Id) -> Option<usize> {
+        self.entries
+            .iter()
+            .position(|entry| entry.contains_window(id))
+    }
+
+    fn replace_window_with(
+        &mut self,
+        win_id: Id,
+        f: impl FnOnce(Box<dyn Layout>) -> Box<dyn Layout>,
+    ) {
+        if let Some(index) = self.index_of_window(win_id) {
+            let mut lyt = self.entries.swap_remove(index);
+            self.entries.push(f(lyt));
+            if self.entries.len() > 1 {
+                let last = self.entries.len() - 1;
+                self.entries.swap(index, last);
+            }
+        }
+    }
+
     fn split(&mut self, current_id: Id, win: Box<Window>, direction: LayoutDirection) {
         if self.direction == direction {
             self.add_window(win);
@@ -54,13 +75,8 @@ impl LinearLayout {
             return;
         }
 
-        if let Some(index) = self
-            .entries
-            .iter()
-            .position(|entry| entry.contains_window(current_id))
-        {
-            let mut lyt = self.entries.swap_remove(index);
-            let replacement = if let Some(splittable) = lyt.into_splittable() {
+        self.replace_window_with(current_id, move |mut lyt| {
+            if let Some(splittable) = lyt.into_splittable() {
                 match direction {
                     LayoutDirection::Horizontal => splittable.vsplit(current_id, win),
                     LayoutDirection::Vertical => splittable.hsplit(current_id, win),
@@ -71,14 +87,8 @@ impl LinearLayout {
                 new_layout.entries.push(lyt);
                 new_layout.entries.push(Box::new(WinLayout::new(win)));
                 Box::new(new_layout)
-            };
-
-            self.entries.push(replacement);
-            if self.entries.len() > 1 {
-                let last = self.entries.len() - 1;
-                self.entries.swap(index, last);
             }
-        }
+        });
     }
 }
 
@@ -118,11 +128,7 @@ impl Layout for LinearLayout {
     }
 
     fn next_focus(&self, current_id: Id, direction: FocusDirection) -> Option<Id> {
-        if let Some(index) = self
-            .entries
-            .iter()
-            .position(|entry| entry.contains_window(current_id))
-        {
+        if let Some(index) = self.index_of_window(current_id) {
             let lyt = self.entries.get(index).unwrap();
             if let Some(next) = lyt.next_focus(current_id, direction) {
                 return Some(next);
@@ -195,6 +201,17 @@ impl SplitableLayout for LinearLayout {
 
     fn vsplit(&mut self, current_id: Id, win: Box<Window>) {
         self.split(current_id, win, LayoutDirection::Horizontal);
+    }
+
+    fn replace_window(&mut self, win_id: Id, layout: Box<dyn Layout>) {
+        self.replace_window_with(win_id, |mut lyt| {
+            if let Some(splittable) = lyt.into_splittable() {
+                splittable.replace_window(win_id, layout);
+                lyt
+            } else {
+                layout
+            }
+        })
     }
 }
 

--- a/src/editing/layout/mod.rs
+++ b/src/editing/layout/mod.rs
@@ -19,6 +19,7 @@ pub trait Layout: Renderable + Resizable {
     fn contains_window(&self, win_id: Id) -> bool {
         self.by_id(win_id).is_some()
     }
+    fn current_focus(&self) -> Option<Id>;
     fn windows_for_buffer(
         &mut self,
         buffer_id: Id,

--- a/src/editing/layout/mod.rs
+++ b/src/editing/layout/mod.rs
@@ -2,6 +2,7 @@ use crate::tui::Renderable;
 
 use super::{window::Window, FocusDirection, Id, Resizable, Size};
 
+pub mod conn;
 mod linear;
 pub mod win;
 

--- a/src/editing/layout/mod.rs
+++ b/src/editing/layout/mod.rs
@@ -35,4 +35,5 @@ pub trait Layout: Renderable + Resizable {
 pub trait SplitableLayout {
     fn hsplit(&mut self, current_id: Id, win: Box<Window>);
     fn vsplit(&mut self, current_id: Id, win: Box<Window>);
+    fn replace_window(&mut self, win_id: Id, layout: Box<dyn Layout>);
 }

--- a/src/editing/layout/win.rs
+++ b/src/editing/layout/win.rs
@@ -37,6 +37,14 @@ impl Layout for WinLayout {
         self.window.id == win_id
     }
 
+    fn current_focus(&self) -> Option<Id> {
+        if self.window.focused {
+            Some(self.window.id)
+        } else {
+            None
+        }
+    }
+
     fn windows_for_buffer(
         &mut self,
         buffer_id: Id,

--- a/src/editing/source/mod.rs
+++ b/src/editing/source/mod.rs
@@ -1,3 +1,5 @@
+use super::Id;
+
 pub enum BufferSource {
     /// The Buffer is in-memory only
     None,
@@ -9,6 +11,10 @@ pub enum BufferSource {
     /// The Buffer receives its content from a network source; such
     /// buffers MUST be read-only
     Connection(String),
+
+    /// The Buffer is in-memory only, as None, but serves to provide
+    /// input to the Connection in the buffer with the given Id
+    ConnectionInputForBuffer(Id),
 }
 
 impl BufferSource {

--- a/src/editing/source/mod.rs
+++ b/src/editing/source/mod.rs
@@ -1,5 +1,6 @@
 use super::Id;
 
+#[derive(Debug, Clone)]
 pub enum BufferSource {
     /// The Buffer is in-memory only
     None,

--- a/src/editing/tabpage.rs
+++ b/src/editing/tabpage.rs
@@ -1,4 +1,4 @@
-use super::{buffers::Buffers, ids::Ids};
+use super::{buffers::Buffers, ids::Ids, layout::conn::ConnLayout, source::BufferSource};
 use super::{layout::SplitableLayout, window::Window};
 use super::{
     layout::{Layout, LinearLayout},
@@ -33,6 +33,15 @@ impl Tabpage {
         }
     }
 
+    pub fn new_connection(&mut self, buffers: &mut Buffers, output_buffer_id: Id) -> ConnLayout {
+        let input_buffer = buffers.create_mut();
+        input_buffer.set_source(BufferSource::ConnectionInputForBuffer(output_buffer_id));
+        ConnLayout {
+            output: Box::new(Window::new(self.ids.next(), output_buffer_id)),
+            input: Box::new(Window::new(self.ids.next(), input_buffer.id())),
+        }
+    }
+
     pub fn current_window(&self) -> &Box<Window> {
         self.by_id(self.current).unwrap()
     }
@@ -51,6 +60,10 @@ impl Tabpage {
 
     pub fn windows_for_buffer(&mut self, buffer_id: Id) -> impl Iterator<Item = &mut Box<Window>> {
         self.layout.windows_for_buffer(buffer_id)
+    }
+
+    pub fn replace_window(&mut self, win_id: Id, layout: Box<dyn Layout>) {
+        self.layout.replace_window(win_id, layout)
     }
 
     pub fn hsplit(&mut self) -> Id {

--- a/src/input/commands/connection.rs
+++ b/src/input/commands/connection.rs
@@ -50,7 +50,8 @@ fn connect(context: &mut CommandHandlerContext, url: String) -> KeyResult {
     tab.replace_window(tab.current_window().id, Box::new(new_window));
     context
         .state_mut()
-        .current_winsbuf()
+        .winsbuf_by_id(buffer_id)
+        .unwrap()
         .append_line(format!("Connecting to {}...", uri));
 
     let mut connections = context.state_mut().connections.take().unwrap();

--- a/src/input/commands/connection.rs
+++ b/src/input/commands/connection.rs
@@ -37,20 +37,17 @@ fn connect(context: &mut CommandHandlerContext, url: String) -> KeyResult {
 
         _ => {
             // otherwise, create a new buffer for the connection
-            let new_id = context.state_mut().buffers.create().id();
-
-            context
-                .state_mut()
-                .buffers
-                .by_id_mut(new_id)
-                .expect("Couldn't find newly-created buffer")
-                .set_source(BufferSource::Connection(url.to_string()));
-
-            new_id
+            let new = context.state_mut().buffers.create_mut();
+            new.set_source(BufferSource::Connection(url.to_string()));
+            new.id()
         }
     };
 
-    context.state_mut().set_current_window_buffer(buffer_id);
+    let state = context.state_mut();
+    let tab = state.tabpages.current_tab_mut();
+    let new_window = tab.new_connection(&mut state.buffers, buffer_id);
+
+    tab.replace_window(tab.current_window().id, Box::new(new_window));
     context
         .state_mut()
         .current_winsbuf()

--- a/src/input/commands/file.rs
+++ b/src/input/commands/file.rs
@@ -24,6 +24,9 @@ declare_commands!(declare_file {
             &BufferSource::Connection(_) => {
                 return Err(KeyError::NotPermitted("Cannot replace Connection buffer".to_string()));
             },
+            &BufferSource::ConnectionInputForBuffer(_) => {
+                return Err(KeyError::NotPermitted("Cannot replace Connection Input buffer".to_string()));
+            },
             &BufferSource::LocalFile(_) => return Err(KeyError::NotPermitted("Buffer backed by a file".to_string())),
             &BufferSource::None => {}, // continue
         };

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -1,0 +1,28 @@
+use std::io;
+
+use crate::editing::source::BufferSource;
+use crate::input::{
+    maps::{KeyHandlerContext, KeyResult},
+    KeyError, KeymapContext,
+};
+
+pub fn send_current_input_buffer<T>(mut ctx: KeyHandlerContext<T>) -> KeyResult {
+    let buffer = ctx.state().current_buffer();
+    let to_send = buffer.get_contents();
+    let conn_buffer_id =
+        if let BufferSource::ConnectionInputForBuffer(conn_buffer_id) = buffer.source() {
+            conn_buffer_id.clone()
+        } else {
+            return Err(KeyError::IO(io::ErrorKind::NotConnected.into()));
+        };
+
+    ctx.state_mut().current_buffer_mut().clear();
+    if let Some(ref mut conns) = ctx.state_mut().connections {
+        if let Some(conn) = conns.by_buffer_id(conn_buffer_id) {
+            conn.send(to_send.clone())?;
+            return Ok(());
+        }
+    }
+
+    Err(KeyError::IO(io::ErrorKind::NotConnected.into()))
+}

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -6,6 +6,11 @@ use crate::input::{
     KeyError, KeymapContext,
 };
 
+/// Send the contents of the current Connection input buffer to
+/// its associated connection (if any)
+///
+/// Returns `io::ErrorKind::NotConnected` if there is no Connection
+/// associated with the current buffer.
 pub fn send_current_input_buffer<T>(mut ctx: KeyHandlerContext<T>) -> KeyResult {
     let buffer = ctx.state().current_buffer();
     let to_send = buffer.get_contents();

--- a/src/input/maps/actions/mod.rs
+++ b/src/input/maps/actions/mod.rs
@@ -1,0 +1,1 @@
+pub mod connection;

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use super::{Key, KeyError, KeySource, KeymapContext};
 
+pub mod actions;
 pub mod vim;
 
 pub struct KeyHandlerContext<'a, T> {
@@ -55,6 +56,15 @@ macro_rules! key_handler {
     ($state_type:ident |?mut $ctx_name:ident| $body:expr) => {{
         Box::new(
             |$ctx_name: crate::input::maps::KeyHandlerContext<$state_type>| {
+                let result: crate::input::maps::KeyResult = $body;
+                result
+            },
+        )
+    }};
+
+    ($state_type:ident move |?mut $ctx_name:ident| $body:expr) => {{
+        Box::new(
+            move |$ctx_name: crate::input::maps::KeyHandlerContext<$state_type>| {
                 let result: crate::input::maps::KeyResult = $body;
                 result
             },

--- a/src/tui/layout/conn.rs
+++ b/src/tui/layout/conn.rs
@@ -1,0 +1,16 @@
+use crate::{
+    editing::layout::conn::ConnLayout,
+    tui::{LayoutContext, RenderContext, Renderable},
+};
+
+impl Renderable for ConnLayout {
+    fn layout(&mut self, ctx: &LayoutContext) {
+        // TODO stretch input to fit content; shrink output to fit input
+        self.output.layout(ctx);
+        self.input.layout(ctx);
+    }
+
+    fn render(&self, ctx: &mut RenderContext) {
+        todo!()
+    }
+}

--- a/src/tui/layout/conn.rs
+++ b/src/tui/layout/conn.rs
@@ -11,6 +11,12 @@ impl Renderable for ConnLayout {
     }
 
     fn render(&self, ctx: &mut RenderContext) {
-        todo!()
+        let mut layout_area = ctx.area.clone();
+        layout_area.height = self.output.size.h;
+        self.output.render(&mut ctx.with_area(layout_area));
+
+        layout_area.y += self.output.size.h;
+        layout_area.height = self.input.size.h;
+        self.input.render(&mut ctx.with_area(layout_area));
     }
 }

--- a/src/tui/layout/conn.rs
+++ b/src/tui/layout/conn.rs
@@ -1,11 +1,37 @@
+use std::cmp::{max, min};
+
 use crate::{
-    editing::layout::conn::ConnLayout,
-    tui::{LayoutContext, RenderContext, Renderable},
+    editing::{layout::conn::ConnLayout, Resizable, Size},
+    tui::{measure::Measurable, LayoutContext, RenderContext, Renderable},
 };
+
+const MIN_OUTPUT_HEIGHT: u16 = 3;
+const MAX_INPUT_HEIGHT: u16 = 5;
 
 impl Renderable for ConnLayout {
     fn layout(&mut self, ctx: &LayoutContext) {
-        // TODO stretch input to fit content; shrink output to fit input
+        // stretch input to fit content; shrink output to fit input:
+        let Size { w, .. } = self.output.size;
+        let input_buffer = ctx.buffer(self.input.buffer).unwrap();
+        let preferred_height = input_buffer.measure_height(self.input.size.w);
+        let available_height = self.output.size.h + self.input.size.h;
+        let available_input_height = max(
+            available_height.checked_sub(MIN_OUTPUT_HEIGHT).unwrap_or(1),
+            1,
+        );
+        let input_height = min(
+            preferred_height,
+            min(available_input_height, MAX_INPUT_HEIGHT),
+        );
+
+        if self.input.size.h != input_height {
+            self.output.resize(Size {
+                w,
+                h: available_height - input_height,
+            });
+            self.input.resize(Size { w, h: input_height });
+        }
+
         self.output.layout(ctx);
         self.input.layout(ctx);
     }
@@ -18,5 +44,43 @@ impl Renderable for ConnLayout {
         layout_area.y += self.output.size.h;
         layout_area.height = self.input.size.h;
         self.input.render(&mut ctx.with_area(layout_area));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tui::rendering::display::tests::TestableDisplay;
+    use crate::tui::tabpage::tests::tabpage;
+    use crate::tui::Size;
+    use indoc::indoc;
+
+    #[test]
+    fn resize_input_to_match_content() {
+        let mut tabpage = tabpage(indoc! {"
+            Take my love
+        "});
+
+        let conn = tabpage
+            .tab
+            .new_connection(&mut tabpage.buffers, tabpage.tab.current_window().buffer);
+
+        let input_bufid = conn.input.buffer;
+
+        tabpage
+            .tab
+            .replace_window(tabpage.tab.current_window().id, Box::new(conn));
+
+        let buffer = tabpage.buffers.by_id_mut(input_bufid).unwrap();
+        buffer.append("Take my land; take me where I cannot stand".into());
+
+        tabpage.size = Size { w: 14, h: 6 };
+        tabpage.render().assert_visual_equals(indoc! {"
+
+
+            Take my love
+            Take my land;
+            take me where
+            I cannot stand
+        "});
     }
 }

--- a/src/tui/layout/mod.rs
+++ b/src/tui/layout/mod.rs
@@ -1,2 +1,3 @@
+pub mod conn;
 pub mod linear;
 pub mod win;

--- a/src/tui/tabpage.rs
+++ b/src/tui/tabpage.rs
@@ -12,13 +12,14 @@ impl Renderable for Tabpage {
 }
 
 #[cfg(test)]
-mod tests {
+pub mod tests {
+    use crate::CursorPosition;
     use tui::layout::Rect;
 
     use crate::{
         app,
         editing::{buffers::Buffers, motion::tests::window, text::TextLines, Resizable, Size},
-        tui::{Display, RenderContext},
+        tui::{Display, LayoutContext, RenderContext},
     };
 
     use super::*;
@@ -72,6 +73,10 @@ mod tests {
                 buffer_override: None,
             };
             self.tab.resize(self.size);
+            self.tab.layout(&mut LayoutContext {
+                buffers: Some(&state.buffers),
+                buffer_override: None,
+            });
             self.tab.render(&mut context);
 
             display
@@ -119,6 +124,7 @@ mod tests {
         "});
         tabpage.tab.hsplit();
         tabpage.tab.vsplit();
+        tabpage.tab.current_window_mut().cursor = CursorPosition { line: 0, col: 11 };
         tabpage.size = Size { w: 14, h: 3 };
 
         tabpage.render().assert_visual_equals(indoc! {"


### PR DESCRIPTION
- WIP: begin ConnLayout got holding Connection windows
- Implement ConnLayout creation
- Fix remaining compile errors
- Enforce and better-handle focus shift on window replacement
- Add basic ConnLayout rendering
- Fix "connecting" line printed to wrong buffer
- Fix connection output processing pace
- Add basic support for sending input to the Connection!
- Auto-resize the input area of a ConnLayout
