### PR TITLE
Fix linewise delete verbs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,6 +145,7 @@ dependencies = [
 name = "iaido"
 version = "0.1.0"
 dependencies = [
+ "bitflags",
  "crossterm 0.19.0",
  "genawaiter",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,4 @@ telnet = "0.1.4"
 url = "2.2.0"
 vte = "0.10.0"
 tokio = { version = "1.2.0", features = ["full"] }
+bitflags = "1.2.1"

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -138,6 +138,12 @@ impl Buffer for MemoryBuffer {
 
         self.content.lines[cursor.line] = new;
     }
+
+    fn insert_lines(&mut self, line_index: usize, text: TextLines) {
+        self.content
+            .lines
+            .splice(line_index..line_index, text.lines);
+    }
 }
 
 impl ToString for MemoryBuffer {

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -172,7 +172,7 @@ mod tests {
         fn after_delete_range() {
             let mut buf = MemoryBuffer::new(0);
             buf.append("Take my love land".into());
-            buf.delete_range(((0, 7).into(), (0, 12).into()));
+            buf.delete_range(((0, 7).into(), (0, 12).into()).into());
             assert_visual_match(&buf, "Take my land");
             assert_eq!(Some(" "), buf.get_char((0, 7).into()));
             assert_eq!(Some("l"), buf.get_char((0, 8).into()));
@@ -182,12 +182,13 @@ mod tests {
     #[cfg(test)]
     mod delete_range {
         use super::*;
+        use crate::editing::motion::MotionFlags;
 
         #[test]
         fn from_line_start() {
             let mut buf = MemoryBuffer::new(0);
             buf.append("Take my land".into());
-            buf.delete_range(((0, 0).into(), (0, 4).into()));
+            buf.delete_range(((0, 0).into(), (0, 4).into()).into());
             assert_visual_match(&buf, " my land");
         }
 
@@ -195,7 +196,11 @@ mod tests {
         fn full_line() {
             let mut buf = MemoryBuffer::new(0);
             buf.append("Take my land".into());
-            buf.delete_range(((0, 0).into(), (0, 12).into()));
+            buf.delete_range(MotionRange(
+                (0, 0).into(),
+                (0, 12).into(),
+                MotionFlags::LINEWISE,
+            ));
             assert_visual_match(&buf, "");
         }
 
@@ -209,7 +214,7 @@ mod tests {
                 "}
                 .into(),
             );
-            buf.delete_range(((0, 0).into(), (1, 12).into()));
+            buf.delete_range(((0, 0).into(), (1, 12).into()).into());
             assert_visual_match(&buf, "");
         }
 
@@ -224,7 +229,7 @@ mod tests {
                 "}
                 .into(),
             );
-            buf.delete_range(((0, 4).into(), (2, 4).into()));
+            buf.delete_range(((0, 4).into(), (2, 4).into()).into());
             assert_visual_match(&buf, "Take me where");
         }
     }

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -29,6 +29,7 @@ pub trait Buffer: HasId + Send + Sync {
 
     fn delete_range(&mut self, range: MotionRange);
     fn insert(&mut self, cursor: CursorPosition, text: TextLine);
+    fn insert_lines(&mut self, line_index: usize, text: TextLines);
 
     fn append_line(&mut self, text: String) {
         self.append_value(ReadValue::Text(text.into()));

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -115,7 +115,7 @@ pub trait Buffer: HasId + Send + Sync {
     }
 
     fn apply_completion(&mut self, old: &Completion, new: &Completion) {
-        self.delete_range(old.replacement_range());
+        self.delete_range(old.replacement_range().into());
         self.insert(new.start(), new.replacement.clone().into());
     }
 }

--- a/src/editing/buffers.rs
+++ b/src/editing/buffers.rs
@@ -43,6 +43,15 @@ impl Buffers {
 
         self.all.last_mut().unwrap()
     }
+
+    #[cfg(test)]
+    pub fn replace(&mut self, buffer: Box<dyn Buffer>) -> Box<dyn Buffer> {
+        let id = buffer.id();
+        let index = self.all.iter().position(|b| b.id() == id).unwrap();
+        let old = self.all.swap_remove(index);
+        self.all.push(buffer);
+        old
+    }
 }
 
 impl fmt::Display for Buffers {

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -44,7 +44,7 @@ impl CursorPosition {
         let line_width = buffer.get(self.line).width();
         CursorPosition {
             line: self.line,
-            col: line_width.checked_sub(1).unwrap_or(0) as u16,
+            col: line_width as u16,
         }
     }
 }

--- a/src/editing/motion/linewise.rs
+++ b/src/editing/motion/linewise.rs
@@ -45,15 +45,12 @@ impl Motion for ToLastLineOfBufferMotion {
 /// Motion that selects the entire current line
 pub struct FullLineMotion;
 impl Motion for FullLineMotion {
-    fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
-        context.cursor().start_of_line()
+    fn is_linewise(&self) -> bool {
+        true
     }
 
-    fn range<T: super::MotionContext>(&self, context: &T) -> super::MotionRange {
-        (
-            context.cursor().start_of_line(),
-            context.cursor().end_of_line(context.buffer()),
-        )
+    fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
+        context.cursor().start_of_line()
     }
 }
 

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -205,8 +205,9 @@ pub mod tests {
                 }
             }
 
-            // take back our buffer
+            // take back our buffer; copy over cursor
             self.buffer = context.state.buffers.replace(self.buffer);
+            self.window.cursor = context.state.current_window_mut().cursor;
 
             self
         }

--- a/src/editing/motion/word.rs
+++ b/src/editing/motion/word.rs
@@ -188,7 +188,8 @@ mod tests {
             "});
 
             // split up the span by deleting a range:
-            ctx.buffer.delete_range(((0, 7).into(), (0, 12).into()));
+            ctx.buffer
+                .delete_range(((0, 7).into(), (0, 12).into()).into());
             ctx.window.cursor = (0, 8).into();
             ctx.assert_visual_match(indoc! {"
                 Take my |land

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -271,8 +271,7 @@ macro_rules! vim_branches {
         $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymapState |$ctx_name| {
             use crate::editing::motion::Motion;
 
-            if let Some(pending_key) = $ctx_name.keymap.pending_linewise_operator_key {
-                $ctx_name.keymap.pending_linewise_operator_key = None;
+            if let Some(pending_key) = $ctx_name.keymap.pending_linewise_operator_key.take() {
                 if pending_key == $keys.into() {
                     // execute linewise action directly:
                     let motion_impl = crate::editing::motion::linewise::FullLineMotion;

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -126,4 +126,38 @@ mod tests {
             |Take me where
         "});
     }
+
+    #[cfg(test)]
+    mod capital_d {
+        use super::*;
+
+        #[test]
+        fn deletes_through_end_of_line() {
+            let ctx = window(indoc! {"
+                Take my love
+                Take |my land
+                Take me where
+            "});
+            ctx.feed_vim("D").assert_visual_match(indoc! {"
+                Take my love
+                Take |
+                Take me where
+            "});
+        }
+
+        #[ignore = "TODO"]
+        #[test]
+        fn retains_empty_line() {
+            let ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.feed_vim("D").assert_visual_match(indoc! {"
+                Take my love
+                |
+                Take me where
+            "});
+        }
+    }
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -145,7 +145,6 @@ mod tests {
             "});
         }
 
-        #[ignore = "TODO"]
         #[test]
         fn retains_empty_line() {
             let ctx = window(indoc! {"

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -107,3 +107,23 @@ pub fn vim_normal_mode() -> VimMode {
         }
     ))
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::editing::motion::tests::window;
+    use indoc::indoc;
+
+    #[test]
+    fn dd() {
+        let ctx = window(indoc! {"
+            Take my love
+            |Take my land
+            Take me where
+        "});
+        ctx.feed_vim("dd").assert_visual_match(indoc! {"
+
+            |Take my love
+            Take me where
+        "});
+    }
+}

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,10 +1,11 @@
 mod window;
 
+use crate::editing::text::TextLine;
 use crate::input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext};
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
-    editing::motion::Motion,
+    editing::motion::{Motion, MotionFlags, MotionRange},
 };
 use crate::{key_handler, vim_tree};
 
@@ -64,7 +65,15 @@ pub fn vim_normal_mode() -> VimMode {
 
         "c" => operator |ctx, motion| {
             ctx.state_mut().current_buffer_mut().delete_range(motion);
-            ctx.state_mut().current_window_mut().cursor = motion.0;
+
+            let MotionRange(start, _, flags) = motion;
+            ctx.state_mut().current_window_mut().cursor = start;
+
+            if flags.contains(MotionFlags::LINEWISE) {
+                // insert a blank line at the cursor
+                ctx.state_mut().current_buffer_mut().insert_lines(start.line, TextLine::from("").into());
+            }
+
             ctx.state_mut().current_window_mut().set_inserting(true);
             Ok(())
         },
@@ -112,6 +121,39 @@ pub fn vim_normal_mode() -> VimMode {
 mod tests {
     use crate::editing::motion::tests::window;
     use indoc::indoc;
+
+    #[cfg(test)]
+    mod c {
+        use super::*;
+
+        #[test]
+        fn cc_retains_line() {
+            let ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.feed_vim("cc").assert_visual_match(indoc! {"
+                Take my love
+                |
+                Take me where
+            "});
+        }
+
+        #[test]
+        fn ck_retains_line() {
+            let ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.feed_vim("ck").assert_visual_match(indoc! {"
+                ~
+                |
+                Take me where
+            "});
+        }
+    }
 
     #[test]
     fn dd() {

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -121,9 +121,9 @@ mod tests {
             Take me where
         "});
         ctx.feed_vim("dd").assert_visual_match(indoc! {"
-
-            |Take my love
-            Take me where
+            ~
+            Take my love
+            |Take me where
         "});
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -2,6 +2,7 @@ pub mod commands;
 pub mod completion;
 pub mod keys;
 pub mod maps;
+pub mod source;
 
 use std::{io, time::Duration};
 

--- a/src/input/source/memory.rs
+++ b/src/input/source/memory.rs
@@ -1,0 +1,30 @@
+use crate::input::{keys::KeysParsable, Key, KeySource};
+
+/// A MemoryKeySource provides a fixed sequence of keys
+/// from memory
+pub struct MemoryKeySource {
+    keys: Vec<Key>,
+}
+
+impl MemoryKeySource {
+    #[allow(unused)]
+    pub fn from_keys<T: KeysParsable>(keys: T) -> Self {
+        MemoryKeySource {
+            keys: keys.into_keys(),
+        }
+    }
+}
+
+impl KeySource for MemoryKeySource {
+    fn poll_key(&mut self, _timeout: std::time::Duration) -> Result<bool, crate::input::KeyError> {
+        Ok(!self.keys.is_empty())
+    }
+
+    fn next_key(&mut self) -> Result<Option<Key>, crate::input::KeyError> {
+        if self.keys.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(self.keys.remove(0)))
+    }
+}

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -1,0 +1,1 @@
+pub mod memory;


### PR DESCRIPTION
Fixes #19 

- Setup a test harness for keymap integration tests
- Add basic fix for linewise delete; add ~ special window() char
- Add Flags to MotionRange; turn it into a struct
- Fix: `D` at line start removed the entire line
- Fix linewise `c` ops not leaving a blank line