### PR TITLE
Add preliminary change tracking with basic undo/redo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9521a61c2b177e0515b69dd1bd0f396a6b322832c54b4ba03cd33030ff6014b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "form_urlencoded"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -147,6 +158,7 @@ version = "0.1.0"
 dependencies = [
  "bitflags",
  "crossterm 0.19.0",
+ "delegate",
  "genawaiter",
  "indoc",
  "telnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ url = "2.2.0"
 vte = "0.10.0"
 tokio = { version = "1.2.0", features = ["full"] }
 bitflags = "1.2.1"
+delegate = "0.5.1"

--- a/src/app/bufwin.rs
+++ b/src/app/bufwin.rs
@@ -16,9 +16,21 @@ impl<'a> BufWin<'a> {
         self.window.scroll_lines(self.buffer, virtual_lines);
     }
 
-    pub fn undo(&mut self) {
+    pub fn redo(&mut self) -> bool {
+        if let Some(cursor) = self.buffer.changes().redo() {
+            self.window.cursor = cursor;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn undo(&mut self) -> bool {
         if let Some(cursor) = self.buffer.changes().undo() {
             self.window.cursor = cursor;
+            true
+        } else {
+            false
         }
     }
 }

--- a/src/app/bufwin.rs
+++ b/src/app/bufwin.rs
@@ -17,7 +17,7 @@ impl<'a> BufWin<'a> {
     }
 
     pub fn undo(&mut self) {
-        if let Some(cursor) = self.buffer.change().undo() {
+        if let Some(cursor) = self.buffer.changes().undo() {
             self.window.cursor = cursor;
         }
     }

--- a/src/app/bufwin.rs
+++ b/src/app/bufwin.rs
@@ -1,4 +1,7 @@
-use crate::editing::{window::Window, Buffer};
+use crate::{
+    editing::{window::Window, Buffer},
+    input::keys::KeysParsable,
+};
 
 /// A BufWin provides convenient mutable access functions on a Window
 /// that require access to its associated buffer
@@ -14,6 +17,14 @@ impl<'a> BufWin<'a> {
 
     pub fn scroll_lines(&mut self, virtual_lines: i32) {
         self.window.scroll_lines(self.buffer, virtual_lines);
+    }
+
+    pub fn begin_insert_change<T: KeysParsable>(&mut self, initial_keys: T) {
+        self.buffer.begin_change(self.window.cursor);
+        for key in initial_keys.into_keys() {
+            self.buffer.push_change_key(key);
+        }
+        self.window.set_inserting(true);
     }
 
     pub fn redo(&mut self) -> bool {

--- a/src/app/bufwin.rs
+++ b/src/app/bufwin.rs
@@ -19,11 +19,15 @@ impl<'a> BufWin<'a> {
         self.window.scroll_lines(self.buffer, virtual_lines);
     }
 
-    pub fn begin_insert_change<T: KeysParsable>(&mut self, initial_keys: T) {
+    pub fn begin_keys_change<T: KeysParsable>(&mut self, initial_keys: T) {
         self.buffer.begin_change(self.window.cursor);
         for key in initial_keys.into_keys() {
             self.buffer.push_change_key(key);
         }
+    }
+
+    pub fn begin_insert_change<T: KeysParsable>(&mut self, initial_keys: T) {
+        self.begin_keys_change(initial_keys);
         self.window.set_inserting(true);
     }
 

--- a/src/app/bufwin.rs
+++ b/src/app/bufwin.rs
@@ -4,15 +4,21 @@ use crate::editing::{window::Window, Buffer};
 /// that require access to its associated buffer
 pub struct BufWin<'a> {
     pub window: &'a mut Box<Window>,
-    pub buffer: &'a Box<dyn Buffer>,
+    pub buffer: &'a mut Box<dyn Buffer>,
 }
 
 impl<'a> BufWin<'a> {
-    pub fn new(window: &'a mut Box<Window>, buffer: &'a Box<dyn Buffer>) -> Self {
+    pub fn new(window: &'a mut Box<Window>, buffer: &'a mut Box<dyn Buffer>) -> Self {
         Self { window, buffer }
     }
 
     pub fn scroll_lines(&mut self, virtual_lines: i32) {
         self.window.scroll_lines(self.buffer, virtual_lines);
+    }
+
+    pub fn undo(&mut self) {
+        if let Some(cursor) = self.buffer.change().undo() {
+            self.window.cursor = cursor;
+        }
     }
 }

--- a/src/app/bufwin.rs
+++ b/src/app/bufwin.rs
@@ -18,7 +18,7 @@ impl<'a> BufWin<'a> {
 
     pub fn redo(&mut self) -> bool {
         if let Some(cursor) = self.buffer.changes().redo() {
-            self.window.cursor = cursor;
+            self.window.cursor = self.window.clamp_cursor(self.buffer, cursor);
             true
         } else {
             false
@@ -27,7 +27,7 @@ impl<'a> BufWin<'a> {
 
     pub fn undo(&mut self) -> bool {
         if let Some(cursor) = self.buffer.changes().undo() {
-            self.window.cursor = cursor;
+            self.window.cursor = self.window.clamp_cursor(self.buffer, cursor);
             true
         } else {
             false

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -123,6 +123,10 @@ impl AppState {
         self.echo_buffer.append(text);
     }
 
+    pub fn echo_str(&mut self, text: &'static str) {
+        self.echo(text.into());
+    }
+
     // ======= keymap conveniences ============================
 
     pub fn backspace(&mut self) {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -82,7 +82,7 @@ impl AppState {
 
     pub fn current_bufwin<'a>(&'a mut self) -> BufWin<'a> {
         if self.prompt.window.focused {
-            BufWin::new(&mut self.prompt.window, &self.prompt.buffer)
+            BufWin::new(&mut self.prompt.window, &mut self.prompt.buffer)
         } else {
             let window_id = self.tabpages.current_tab_mut().current_window().id;
             if let Some(bufwin) = self.bufwin_by_id(window_id) {
@@ -96,7 +96,7 @@ impl AppState {
     pub fn bufwin_by_id<'a>(&'a mut self, window_id: usize) -> Option<BufWin<'a>> {
         if let Some(tabpage) = self.tabpages.containing_window_mut(window_id) {
             if let Some(window) = tabpage.by_id_mut(window_id) {
-                if let Some(buffer) = self.buffers.by_id(window.buffer) {
+                if let Some(buffer) = self.buffers.by_id_mut(window.buffer) {
                     return Some(BufWin::new(window, buffer));
                 }
             }

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -1,10 +1,12 @@
 use crate::editing::{
-    motion::{MotionFlags, MotionRange},
+    motion::MotionRange,
     source::BufferSource,
     text::EditableLine,
     text::{TextLine, TextLines},
     Buffer, CursorPosition, HasId,
 };
+
+use super::{util::motion_to_line_ranges, CopiedRange};
 
 pub struct MemoryBuffer {
     id: usize,
@@ -48,57 +50,30 @@ impl Buffer for MemoryBuffer {
         &self.content.lines[line_index]
     }
 
-    fn delete_range(&mut self, range: MotionRange) {
-        let MotionRange(
-            CursorPosition {
-                line: first_line,
-                col: first_col,
-            },
-            CursorPosition {
-                line: last_line,
-                col: last_col,
-            },
-            flags,
-        ) = range;
+    fn delete_range(&mut self, range: MotionRange) -> CopiedRange {
+        let (first_line, last_line) = range.lines();
+        let ranges = motion_to_line_ranges(range);
 
-        let ranges = (first_line..=last_line).map(|line_index| {
-            if line_index == first_line && line_index == last_line {
-                // single line range:
-                (first_col, Some(last_col))
-            } else if line_index == first_line {
-                (first_col, None)
-            } else if line_index == last_line {
-                (0, Some(last_col))
-            } else {
-                (0, None)
-            }
-        });
-
-        let linewise = first_line < last_line || flags.contains(MotionFlags::LINEWISE);
-        let mut consumed_first_line = false;
-        let mut consumed_last_line = false;
+        let mut copy = CopiedRange::default();
         let mut line_index = first_line;
         let last_line_index = last_line - first_line;
-        for (i, (start, optional_end)) in ranges.enumerate() {
-            let line = &self.content.lines[line_index];
-            let end = if let Some(v) = optional_end {
-                v as usize
-            } else {
-                line.width()
-            };
-
-            if start == 0 && end == line.width() && linewise {
+        for (i, range) in ranges.enumerate() {
+            if range.is_whole_line(line_index, self) {
                 // delete the whole line
-                self.content.lines.remove(line_index);
+                copy.text.lines.push(self.content.lines.remove(line_index));
                 if i == 0 {
-                    consumed_first_line = true;
+                    copy.leading_newline = true;
                 }
                 if i == last_line_index {
-                    consumed_last_line = true;
+                    copy.trailing_newline = true;
                 }
             } else {
                 // delete within the line
-                let mut new_line = line.subs(0, start as usize);
+                let (start, end) = range.resolve(line_index, self);
+                let line = &self.content.lines[line_index];
+                copy.text.lines.push(line.subs(start, end));
+
+                let mut new_line = line.subs(0, start);
                 let mut rest = line.subs(end, line.width());
                 new_line.append(&mut rest);
 
@@ -109,12 +84,14 @@ impl Buffer for MemoryBuffer {
 
         // if we did a partial delete on both the first and last lines,
         // they need to be spliced together
-        if last_line > first_line && !consumed_first_line && !consumed_last_line {
+        if last_line > first_line && copy.is_partial() {
             let to_splice_line = &self.content.lines[first_line + 1];
             let mut to_splice = to_splice_line.subs(0, to_splice_line.width());
             self.content.lines[first_line].append(&mut to_splice);
             self.content.lines.remove(first_line + 1);
         }
+
+        return copy;
     }
 
     fn insert(&mut self, cursor: CursorPosition, mut text: TextLine) {
@@ -142,6 +119,43 @@ impl Buffer for MemoryBuffer {
             self.content
                 .lines
                 .splice(line_index..line_index, text.lines);
+        }
+    }
+
+    fn insert_range(&mut self, cursor: CursorPosition, mut copied: CopiedRange) {
+        // NOTE: we insert in reverse order, progressively "popping" off of the end of the vector,
+        // to avoid having to copy. `copied` is probably already a copy, and it's cleaner (I
+        // think?) to just assume the caller has made a copy if necessary than to always have to
+        // make one defensively
+        let mut start = 0;
+        let mut end = copied.text.lines.len();
+        if !copied.trailing_newline {
+            // We have to de-splice this line
+            let end_of_line = self
+                .get_line_width(cursor.line)
+                .unwrap_or(cursor.col as usize) as u16;
+            let range: MotionRange = (cursor, cursor.with_col(end_of_line)).into();
+            let after_last_line = self.delete_range(range).text;
+            self.insert_lines(cursor.line + 1, after_last_line);
+            self.insert(
+                (cursor.line + 1, 0).into(),
+                copied.text.lines.remove(end - 1).into(),
+            );
+
+            end -= 1;
+        }
+
+        if !copied.leading_newline {
+            start += 1;
+        }
+
+        if end > 0 {
+            let lines: Vec<TextLine> = copied.text.lines.splice(start..end, vec![]).collect();
+            self.insert_lines(cursor.line + start, TextLines::from(lines));
+        }
+
+        if !copied.leading_newline {
+            self.insert(cursor, copied.text.lines.remove(0));
         }
     }
 }
@@ -291,6 +305,56 @@ mod tests {
             let mut buf = MemoryBuffer::new(0);
             buf.append_value(ReadValue::Text("serenity".into()));
             assert_visual_match(&buf, "serenity");
+        }
+    }
+
+    #[cfg(test)]
+    mod insert_range {
+        use super::*;
+
+        #[test]
+        fn neither_leading_nor_trailing() {
+            let mut buf = MemoryBuffer::new(0);
+            buf.append("Take my stand".into());
+
+            buf.insert_range(
+                (0, 8).into(),
+                CopiedRange {
+                    text: TextLines::raw("love\nTake my land\nTake me where I cannot "),
+                    leading_newline: false,
+                    trailing_newline: false,
+                },
+            );
+
+            assert_visual_match(
+                &buf,
+                indoc! {"
+                    Take my love
+                    Take my land
+                    Take me where I cannot stand
+                "},
+            );
+        }
+
+        #[test]
+        fn lines_into_empty() {
+            let mut buf = MemoryBuffer::new(0);
+            buf.insert_range(
+                (0, 0).into(),
+                CopiedRange {
+                    text: TextLines::raw("Take my love\nTake my land"),
+                    leading_newline: true,
+                    trailing_newline: true,
+                },
+            );
+
+            assert_visual_match(
+                &buf,
+                indoc! {"
+                    Take my love
+                    Take my land
+                "},
+            );
         }
     }
 }

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -40,10 +40,6 @@ impl Buffer for MemoryBuffer {
         self.content.height()
     }
 
-    fn append(&mut self, text: TextLines) {
-        self.content.extend(text);
-    }
-
     fn clear(&mut self) {
         self.content.lines.clear();
     }
@@ -140,9 +136,13 @@ impl Buffer for MemoryBuffer {
     }
 
     fn insert_lines(&mut self, line_index: usize, text: TextLines) {
-        self.content
-            .lines
-            .splice(line_index..line_index, text.lines);
+        if line_index == self.lines_count() {
+            self.content.extend(text);
+        } else {
+            self.content
+                .lines
+                .splice(line_index..line_index, text.lines);
+        }
     }
 }
 

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -154,36 +154,25 @@ impl Buffer for MemoryBuffer {
             self.insert_lines(cursor.line + start, TextLines::from(lines));
         }
 
-        if !copied.leading_newline {
+        if !copied.leading_newline && end > start {
             self.insert(cursor, copied.text.lines.remove(0));
         }
     }
 }
 
-impl ToString for MemoryBuffer {
-    fn to_string(&self) -> String {
-        let mut s = String::default();
-        for i in 0..self.lines_count() {
-            s.push_str(self.get(i).to_string().as_str());
-            s.push_str("\n");
-        }
-        return s;
-    }
-}
-
 #[cfg(test)]
-mod tests {
+pub mod tests {
     use super::*;
     use indoc::indoc;
 
-    fn assert_visual_match(buf: &MemoryBuffer, s: &'static str) {
-        let actual = buf.to_string();
+    pub fn assert_visual_match<T: Buffer>(buf: &T, s: &'static str) {
+        let actual = buf.get_contents();
         let expected = MemoryBuffer {
             id: 0,
             content: s.into(),
             source: BufferSource::None,
         }
-        .to_string();
+        .get_contents();
 
         assert_eq!(actual, expected);
     }
@@ -196,7 +185,7 @@ mod tests {
         fn after_delete_range() {
             let mut buf = MemoryBuffer::new(0);
             buf.append("Take my love land".into());
-            buf.delete_range(((0, 7).into(), (0, 12).into()).into());
+            buf.delete_range(((0, 7), (0, 12)).into());
             assert_visual_match(&buf, "Take my land");
             assert_eq!(Some(" "), buf.get_char((0, 7).into()));
             assert_eq!(Some("l"), buf.get_char((0, 8).into()));
@@ -212,7 +201,7 @@ mod tests {
         fn from_line_start() {
             let mut buf = MemoryBuffer::new(0);
             buf.append("Take my land".into());
-            buf.delete_range(((0, 0).into(), (0, 4).into()).into());
+            buf.delete_range(((0, 0), (0, 4)).into());
             assert_visual_match(&buf, " my land");
         }
 
@@ -238,7 +227,7 @@ mod tests {
                 "}
                 .into(),
             );
-            buf.delete_range(((0, 0).into(), (1, 12).into()).into());
+            buf.delete_range(((0, 0), (1, 12)).into());
             assert_visual_match(&buf, "");
         }
 
@@ -253,7 +242,7 @@ mod tests {
                 "}
                 .into(),
             );
-            buf.delete_range(((0, 4).into(), (2, 4).into()).into());
+            buf.delete_range(((0, 4), (2, 4)).into());
             assert_visual_match(&buf, "Take me where");
         }
     }

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -16,7 +16,7 @@ use super::{
     CursorPosition, HasId,
 };
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct CopiedRange {
     pub text: TextLines,
 

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -93,7 +93,7 @@ pub trait Buffer: HasId + Send + Sync {
     fn can_handle_change(&self) -> bool {
         false
     }
-    fn change(&mut self) -> ChangeHandler {
+    fn changes(&mut self) -> ChangeHandler {
         panic!("This Buffer implementation cannot handle changes");
     }
 

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -115,7 +115,7 @@ pub trait Buffer: HasId + Send + Sync {
 
     fn append(&mut self, text: TextLines) {
         self.begin_change(CursorPosition {
-            line: self.lines_count().checked_sub(0).unwrap_or(0),
+            line: self.lines_count().checked_sub(1).unwrap_or(0),
             col: 0,
         });
         self.insert_lines(self.lines_count(), text);

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -11,7 +11,7 @@ use crate::{connection::ReadValue, input::completion::Completion};
 
 use super::{
     change::handler::ChangeHandler,
-    motion::MotionRange,
+    motion::{MotionFlags, MotionRange},
     source::BufferSource,
     text::{EditableLine, TextLine, TextLines},
     CursorPosition, HasId,
@@ -60,6 +60,16 @@ impl CopiedRange {
             },
         };
         return end;
+    }
+
+    pub fn motion_range(&self, start: CursorPosition) -> MotionRange {
+        let end = self.end_position(start);
+        let flags = if self.is_partial() {
+            MotionFlags::NONE
+        } else {
+            MotionFlags::LINEWISE
+        };
+        MotionRange(start, end, flags)
     }
 
     pub fn is_partial(&self) -> bool {

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -7,7 +7,10 @@ pub use undoable::UndoableBuffer;
 
 use std::fmt;
 
-use crate::{connection::ReadValue, input::completion::Completion};
+use crate::{
+    connection::ReadValue,
+    input::{completion::Completion, Key},
+};
 
 use super::{
     change::handler::ChangeHandler,
@@ -107,6 +110,7 @@ pub trait Buffer: HasId + Send + Sync {
         panic!("This Buffer implementation cannot handle changes");
     }
     fn begin_change(&mut self, _cursor: CursorPosition) {}
+    fn push_change_key(&mut self, _key: Key) {}
     fn end_change(&mut self) {}
 
     //

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -1,5 +1,7 @@
 pub mod memory;
+pub mod undoable;
 pub use memory::MemoryBuffer;
+pub use undoable::UndoableBuffer;
 
 use std::fmt;
 
@@ -23,13 +25,16 @@ pub trait Buffer: HasId + Send + Sync {
     }
 
     fn lines_count(&self) -> usize;
-    fn append(&mut self, text: TextLines);
     fn clear(&mut self);
     fn get(&self, line_index: usize) -> &TextLine;
 
     fn delete_range(&mut self, range: MotionRange);
     fn insert(&mut self, cursor: CursorPosition, text: TextLine);
     fn insert_lines(&mut self, line_index: usize, text: TextLines);
+
+    fn append(&mut self, text: TextLines) {
+        self.insert_lines(self.lines_count(), text);
+    }
 
     fn append_line(&mut self, text: String) {
         self.append_value(ReadValue::Text(text.into()));

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -133,10 +133,10 @@ mod tests {
     mod delete_range {
         use super::*;
 
-        use crate::editing::buffer::memory::tests::assert_visual_match;
+        use crate::editing::buffer::memory::tests::{assert_visual_match, TestableBuffer};
 
         #[test]
-        fn undo_within_line() {
+        fn undo_delete_within_line() {
             let mut buffer = buffer(indoc! {"
                 Take my love
             "});
@@ -146,6 +146,25 @@ mod tests {
             let last_change = buffer.changes.take_last().unwrap();
             let mut boxed: Box<dyn Buffer> = Box::new(buffer);
             last_change.undo(&mut boxed);
+            boxed.assert_visual_match("Take my love");
+        }
+
+        #[test]
+        fn undo_partial_plus_full_line_delete() {
+            let mut buffer = buffer(indoc! {"
+                Take my love
+                Take my
+            "});
+            buffer.delete_range(((0, 4), (1, 7)).into());
+            assert_visual_match(&buffer, "Take");
+
+            let last_change = buffer.changes.take_last().unwrap();
+            let mut boxed: Box<dyn Buffer> = Box::new(buffer);
+            last_change.undo(&mut boxed);
+            boxed.assert_visual_match(indoc! {"
+                Take my love
+                Take my
+            "});
         }
     }
 }

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -1,12 +1,15 @@
 use delegate::delegate;
 use editing::text::TextLines;
 
-use crate::editing::{
-    self,
-    change::{handler::ChangeHandler, manager::ChangeManager, UndoAction},
-    motion::{MotionFlags, MotionRange},
-    text::TextLine,
-    CursorPosition, HasId, Id,
+use crate::{
+    editing::{
+        self,
+        change::{handler::ChangeHandler, manager::ChangeManager, UndoAction},
+        motion::{MotionFlags, MotionRange},
+        text::TextLine,
+        CursorPosition, HasId, Id,
+    },
+    input::Key,
 };
 
 use super::{Buffer, CopiedRange};
@@ -58,6 +61,7 @@ impl Buffer for UndoableBuffer {
     delegate! {
         to self.changes {
             fn begin_change(&mut self, cursor: CursorPosition);
+            fn push_change_key(&mut self, key: Key);
             fn end_change(&mut self);
         }
     }

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -1,0 +1,85 @@
+use delegate::delegate;
+use editing::text::TextLines;
+
+use crate::editing::{
+    self,
+    change::{manager::ChangeManager, UndoAction},
+    motion::{MotionFlags, MotionRange},
+    text::TextLine,
+    CursorPosition, HasId, Id,
+};
+
+use super::Buffer;
+
+pub struct UndoableBuffer {
+    base: Box<dyn Buffer>,
+    changes: ChangeManager,
+}
+
+impl HasId for UndoableBuffer {
+    delegate! {
+        to self.base {
+            fn id(&self) -> Id;
+        }
+    }
+}
+
+impl Buffer for UndoableBuffer {
+    delegate! {
+        to self.base {
+            fn source(&self) -> &crate::editing::source::BufferSource;
+            fn set_source(&mut self, source: crate::editing::source::BufferSource);
+            fn get(&self, line_index: usize) -> &crate::editing::text::TextLine;
+            fn lines_count(&self) -> usize;
+            fn clear(&mut self);
+        }
+    }
+
+    fn delete_range(&mut self, range: MotionRange) {
+        self.changes.begin_change(range.0);
+        // TODO this may be tricky to enqueue...
+
+        self.base.delete_range(range);
+        self.changes.end_change();
+    }
+
+    fn insert(&mut self, cursor: CursorPosition, text: TextLine) {
+        self.changes.begin_change(cursor);
+        let end = CursorPosition {
+            line: cursor.line,
+            col: cursor.col + text.width() as u16,
+        };
+
+        self.base.insert(cursor, text);
+
+        self.changes
+            .enqueue_undo(UndoAction::DeleteRange(MotionRange(
+                cursor,
+                end,
+                MotionFlags::NONE,
+            )));
+        self.changes.end_change();
+    }
+
+    fn insert_lines(&mut self, line_index: usize, text: TextLines) {
+        let start = CursorPosition {
+            line: line_index,
+            col: 0,
+        };
+        let end = CursorPosition {
+            line: line_index + text.lines.len(),
+            col: 0,
+        };
+        self.changes.begin_change(start);
+
+        self.base.insert_lines(line_index, text);
+
+        self.changes
+            .enqueue_undo(UndoAction::DeleteRange(MotionRange(
+                start,
+                end,
+                MotionFlags::LINEWISE,
+            )));
+        self.changes.end_change();
+    }
+}

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -55,6 +55,13 @@ impl Buffer for UndoableBuffer {
         }
     }
 
+    delegate! {
+        to self.changes {
+            fn begin_change(&mut self, cursor: CursorPosition);
+            fn end_change(&mut self);
+        }
+    }
+
     //
     // Handle change
     //
@@ -307,6 +314,24 @@ mod tests {
 
             buffer.changes().undo();
             buffer.assert_visual_match("Take my love");
+        }
+    }
+
+    #[cfg(test)]
+    mod append {
+        use super::*;
+
+        #[test]
+        fn undo_append_to_empty_buffer() {
+            let mut buffer = buffer("");
+            buffer.append("Take my love".into());
+            buffer.assert_visual_match(indoc! {"
+                Take my love
+            "});
+
+            buffer.changes().undo();
+            assert_eq!(buffer.lines_count(), 0);
+            buffer.assert_visual_match("");
         }
     }
 }

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -63,7 +63,7 @@ impl Buffer for UndoableBuffer {
         true
     }
 
-    fn change(&mut self) -> ChangeHandler {
+    fn changes(&mut self) -> ChangeHandler {
         ChangeHandler::new(&mut self.base, &mut self.changes)
     }
 
@@ -166,7 +166,7 @@ mod tests {
             buffer.delete_range(((0, 4), (0, 7)).into());
             buffer.assert_visual_match("Take love");
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take my love");
         }
 
@@ -179,7 +179,7 @@ mod tests {
             buffer.delete_range(((0, 4), (1, 7)).into());
             buffer.assert_visual_match("Take");
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match(indoc! {"
                 Take my love
                 Take my
@@ -196,7 +196,7 @@ mod tests {
             buffer.delete_range(((0, 7), (2, 7)).into());
             buffer.assert_visual_match("Take my where");
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match(indoc! {"
                 Take my love
                 Take my land
@@ -220,7 +220,7 @@ mod tests {
             buffer.insert_range((0, 4).into(), range);
             buffer.assert_visual_match("Take my love");
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take love");
         }
 
@@ -239,7 +239,7 @@ mod tests {
                 Take my land
             "});
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take");
         }
 
@@ -260,7 +260,7 @@ mod tests {
                 Take me where
             "});
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take my where");
         }
     }
@@ -277,7 +277,7 @@ mod tests {
             buffer.insert((0, 4).into(), " my".into());
             buffer.assert_visual_match("Take my love");
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take love");
         }
     }
@@ -297,7 +297,7 @@ mod tests {
                 Take my land
             "});
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take my land");
         }
 
@@ -312,7 +312,7 @@ mod tests {
                 Take my land
             "});
 
-            buffer.change().undo();
+            buffer.changes().undo();
             buffer.assert_visual_match("Take my love");
         }
     }

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -166,9 +166,6 @@ mod tests {
             buffer.delete_range(((0, 4), (0, 7)).into());
             buffer.assert_visual_match("Take love");
 
-            // let last_change = buffer.changes.take_last().unwrap();
-            // let mut boxed: Box<dyn Buffer> = Box::new(buffer);
-            // last_change.undo(&mut boxed);
             buffer.change().undo();
             buffer.assert_visual_match("Take my love");
         }

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -122,19 +122,12 @@ impl Buffer for UndoableBuffer {
     }
 
     fn insert_range(&mut self, cursor: CursorPosition, copied: CopiedRange) {
-        let end = copied.end_position(cursor);
-        let flags = if copied.is_partial() {
-            MotionFlags::NONE
-        } else {
-            MotionFlags::LINEWISE
-        };
-
         self.changes.begin_change(cursor);
 
+        self.changes
+            .enqueue_undo(UndoAction::DeleteRange(copied.motion_range(cursor)));
         self.base.insert_range(cursor, copied);
 
-        self.changes
-            .enqueue_undo(UndoAction::DeleteRange(MotionRange(cursor, end, flags)));
         self.changes.end_change();
     }
 }

--- a/src/editing/buffer/util.rs
+++ b/src/editing/buffer/util.rs
@@ -1,0 +1,64 @@
+use crate::editing::{
+    motion::{MotionFlags, MotionRange},
+    CursorPosition,
+};
+
+use super::Buffer;
+
+pub enum LineRange {
+    WholeLine,
+    FromCol(u16, bool),
+    ToCol(u16, bool),
+    Precise(u16, u16, bool),
+}
+
+impl LineRange {
+    pub fn resolve<T: Buffer>(&self, line_index: usize, buffer: &T) -> (usize, usize) {
+        let width = buffer.get_line_width(line_index).unwrap_or(0) as u16;
+        match self {
+            LineRange::WholeLine => (0, width as usize),
+            &LineRange::FromCol(col, _) => (col as usize, width as usize),
+            &LineRange::ToCol(col, _) => (0, col as usize),
+            &LineRange::Precise(start, end, _) => (start as usize, end as usize),
+        }
+    }
+
+    pub fn is_whole_line<T: Buffer>(&self, line_index: usize, buffer: &T) -> bool {
+        let width = buffer.get_line_width(line_index).unwrap_or(0) as u16;
+        match self {
+            LineRange::WholeLine => true,
+            &LineRange::FromCol(col, linewise) if col == 0 => linewise,
+            &LineRange::ToCol(col, linewise) if col == width => linewise,
+            &LineRange::Precise(start, end, linewise) if (start, end) == (0, width) => linewise,
+            _ => false,
+        }
+    }
+}
+
+pub fn motion_to_line_ranges(range: MotionRange) -> impl Iterator<Item = LineRange> {
+    let MotionRange(
+        CursorPosition {
+            line: first_line,
+            col: first_col,
+        },
+        CursorPosition {
+            line: last_line,
+            col: last_col,
+        },
+        flags,
+    ) = range;
+
+    let linewise = flags.contains(MotionFlags::LINEWISE) || last_line > first_line;
+    (first_line..=last_line).map(move |line_index| {
+        if line_index == first_line && line_index == last_line {
+            // single line range:
+            LineRange::Precise(first_col, last_col, linewise)
+        } else if line_index == first_line {
+            LineRange::FromCol(first_col, linewise)
+        } else if line_index == last_line {
+            LineRange::ToCol(last_col, linewise)
+        } else {
+            LineRange::WholeLine
+        }
+    })
+}

--- a/src/editing/change/handler.rs
+++ b/src/editing/change/handler.rs
@@ -1,4 +1,4 @@
-use crate::editing::Buffer;
+use crate::editing::{Buffer, CursorPosition};
 
 use super::manager::ChangeManager;
 
@@ -13,9 +13,11 @@ impl<'a> ChangeHandler<'a> {
         Self { buffer, changes }
     }
 
-    pub fn undo(&mut self) {
+    pub fn undo(&mut self) -> Option<CursorPosition> {
         if let Some(change) = self.changes.take_last() {
-            change.undo(self.buffer);
+            Some(change.undo(self.buffer))
+        } else {
+            None
         }
     }
 }

--- a/src/editing/change/handler.rs
+++ b/src/editing/change/handler.rs
@@ -1,0 +1,21 @@
+use crate::editing::Buffer;
+
+use super::manager::ChangeManager;
+
+/// Utility struct for handling the performance of changes on a Buffer
+pub struct ChangeHandler<'a> {
+    buffer: &'a mut Box<dyn Buffer>,
+    changes: &'a mut ChangeManager,
+}
+
+impl<'a> ChangeHandler<'a> {
+    pub fn new(buffer: &'a mut Box<dyn Buffer>, changes: &'a mut ChangeManager) -> Self {
+        Self { buffer, changes }
+    }
+
+    pub fn undo(&mut self) {
+        if let Some(change) = self.changes.take_last() {
+            change.undo(self.buffer);
+        }
+    }
+}

--- a/src/editing/change/handler.rs
+++ b/src/editing/change/handler.rs
@@ -1,6 +1,6 @@
 use crate::editing::{Buffer, CursorPosition};
 
-use super::manager::ChangeManager;
+use super::{manager::ChangeManager, Change};
 
 /// Utility struct for handling the performance of changes on a Buffer
 pub struct ChangeHandler<'a> {
@@ -11,6 +11,14 @@ pub struct ChangeHandler<'a> {
 impl<'a> ChangeHandler<'a> {
     pub fn new(buffer: &'a mut Box<dyn Buffer>, changes: &'a mut ChangeManager) -> Self {
         Self { buffer, changes }
+    }
+
+    pub fn take_last(&mut self) -> Option<Change> {
+        self.changes.take_last()
+    }
+
+    pub fn push(&mut self, change: Change) {
+        self.changes.push(change)
     }
 
     pub fn undo(&mut self) -> Option<CursorPosition> {

--- a/src/editing/change/handler.rs
+++ b/src/editing/change/handler.rs
@@ -1,3 +1,5 @@
+use delegate::delegate;
+
 use crate::editing::{Buffer, CursorPosition};
 
 use super::{manager::ChangeManager, Change};
@@ -13,12 +15,12 @@ impl<'a> ChangeHandler<'a> {
         Self { buffer, changes }
     }
 
-    pub fn push(&mut self, change: Change) {
-        self.changes.push(change)
-    }
-
-    pub fn take_last(&mut self) -> Option<Change> {
-        self.changes.take_last()
+    delegate! {
+        to self.changes {
+            pub fn clear(&mut self);
+            pub fn push(&mut self, change: Change);
+            pub fn take_last(&mut self) -> Option<Change>;
+        }
     }
 
     pub fn undo(&mut self) -> Option<CursorPosition> {

--- a/src/editing/change/handler.rs
+++ b/src/editing/change/handler.rs
@@ -13,17 +13,31 @@ impl<'a> ChangeHandler<'a> {
         Self { buffer, changes }
     }
 
-    pub fn take_last(&mut self) -> Option<Change> {
-        self.changes.take_last()
-    }
-
     pub fn push(&mut self, change: Change) {
         self.changes.push(change)
     }
 
+    pub fn take_last(&mut self) -> Option<Change> {
+        self.changes.take_last()
+    }
+
     pub fn undo(&mut self) -> Option<CursorPosition> {
         if let Some(change) = self.changes.take_last() {
-            Some(change.undo(self.buffer))
+            let redo = change.undo(self.buffer);
+            let result = Some(redo.cursor);
+            self.changes.push_redo(redo);
+            result
+        } else {
+            None
+        }
+    }
+
+    pub fn redo(&mut self) -> Option<CursorPosition> {
+        if let Some(change) = self.changes.take_last_redo() {
+            let undo = change.undo(self.buffer);
+            let result = Some(undo.cursor);
+            self.changes.push(undo);
+            result
         } else {
             None
         }

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -42,4 +42,8 @@ impl ChangeManager {
             .undo_actions
             .push(action);
     }
+
+    pub fn take_last(&mut self) -> Option<Change> {
+        self.undo_stack.pop()
+    }
 }

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -46,6 +46,14 @@ impl ChangeManager {
             .push(action);
     }
 
+    /// After reading in a file, for example, we should not have
+    /// any undo history
+    pub fn clear(&mut self) {
+        self.undo_stack.clear();
+        self.redo_stack.clear();
+        self.current_change = None;
+    }
+
     pub fn push(&mut self, change: Change) {
         self.undo_stack.push(change);
     }

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -1,4 +1,6 @@
-use super::Change;
+use crate::editing::CursorPosition;
+
+use super::{Change, UndoAction};
 
 pub struct ChangeManager {
     change_depth: u16,
@@ -13,5 +15,31 @@ impl Default for ChangeManager {
             current_change: None,
             undo_stack: Vec::default(),
         }
+    }
+}
+
+impl ChangeManager {
+    pub fn begin_change(&mut self, cursor: CursorPosition) {
+        self.change_depth += 1;
+        if self.current_change.is_none() {
+            self.current_change = Some(Change::new(cursor));
+        }
+    }
+
+    pub fn end_change(&mut self) {
+        self.change_depth -= 1;
+        if self.change_depth == 0 {
+            if let Some(change) = self.current_change.take() {
+                self.undo_stack.push(change);
+            }
+        }
+    }
+
+    pub fn enqueue_undo(&mut self, action: UndoAction) {
+        self.current_change
+            .as_mut()
+            .expect("No active change")
+            .undo_actions
+            .push(action);
     }
 }

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -43,6 +43,10 @@ impl ChangeManager {
             .push(action);
     }
 
+    pub fn push(&mut self, change: Change) {
+        self.undo_stack.push(change);
+    }
+
     pub fn take_last(&mut self) -> Option<Change> {
         self.undo_stack.pop()
     }

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -1,0 +1,17 @@
+use super::Change;
+
+pub struct ChangeManager {
+    change_depth: u16,
+    current_change: Option<Change>,
+    undo_stack: Vec<Change>,
+}
+
+impl Default for ChangeManager {
+    fn default() -> Self {
+        Self {
+            change_depth: 0,
+            current_change: None,
+            undo_stack: Vec::default(),
+        }
+    }
+}

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -1,4 +1,4 @@
-use crate::editing::CursorPosition;
+use crate::{editing::CursorPosition, input::Key};
 
 use super::{Change, UndoAction};
 
@@ -28,7 +28,17 @@ impl ChangeManager {
         }
     }
 
+    pub fn push_change_key(&mut self, key: Key) {
+        if let Some(change) = self.current_change.as_mut() {
+            change.keys.push(key);
+        }
+    }
+
     pub fn end_change(&mut self) {
+        if self.change_depth == 0 {
+            panic!("unbalanced end_change; was a begin_change missed when entering insert?");
+        }
+
         self.change_depth -= 1;
         if self.change_depth == 0 {
             if let Some(change) = self.current_change.take() {

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -6,6 +6,7 @@ pub struct ChangeManager {
     change_depth: u16,
     current_change: Option<Change>,
     undo_stack: Vec<Change>,
+    redo_stack: Vec<Change>,
 }
 
 impl Default for ChangeManager {
@@ -14,6 +15,7 @@ impl Default for ChangeManager {
             change_depth: 0,
             current_change: None,
             undo_stack: Vec::default(),
+            redo_stack: Vec::default(),
         }
     }
 }
@@ -32,6 +34,7 @@ impl ChangeManager {
             if let Some(change) = self.current_change.take() {
                 self.undo_stack.push(change);
             }
+            self.redo_stack.clear();
         }
     }
 
@@ -49,5 +52,13 @@ impl ChangeManager {
 
     pub fn take_last(&mut self) -> Option<Change> {
         self.undo_stack.pop()
+    }
+
+    pub fn push_redo(&mut self, change: Change) {
+        self.redo_stack.push(change);
+    }
+
+    pub fn take_last_redo(&mut self) -> Option<Change> {
+        self.redo_stack.pop()
     }
 }

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -1,0 +1,46 @@
+pub mod manager;
+
+use crate::input::Key;
+
+use super::{
+    motion::MotionRange,
+    text::{TextLine, TextLines},
+    Buffer, CursorPosition,
+};
+
+pub enum UndoAction {
+    DeleteRange(MotionRange),
+    Insert(CursorPosition, TextLine),
+    InsertLines(usize, TextLines),
+}
+
+pub struct Change {
+    /// Where this Change occurred (for redoing, if undone)
+    cursor: CursorPosition,
+
+    /// The Keys that triggered this change
+    pub keys: Vec<Key>,
+
+    /// Actions to be performed in *reverse order* to undo the change
+    undo_actions: Vec<UndoAction>,
+}
+
+impl Change {
+    pub fn new(cursor: CursorPosition) -> Self {
+        Self {
+            cursor,
+            keys: Vec::default(),
+            undo_actions: Vec::default(),
+        }
+    }
+
+    pub fn undo(&self, buffer: &mut Box<dyn Buffer>) {
+        for action in self.undo_actions.iter().rev() {
+            match action {
+                &UndoAction::DeleteRange(range) => buffer.delete_range(range),
+                &UndoAction::Insert(pos, ref text) => buffer.insert(pos, text.clone()),
+                &UndoAction::InsertLines(pos, ref lines) => buffer.insert_lines(pos, lines.clone()),
+            };
+        }
+    }
+}

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -35,26 +35,23 @@ impl Change {
     /// Returns a Change for redoing this undo; the keys for the new
     /// Change are copied from this one
     pub fn undo(&self, buffer: &mut Box<dyn Buffer>) -> Change {
-        let mut cursor = CursorPosition::default();
         let mut undo_actions = Vec::default();
 
         for action in self.undo_actions.iter().rev() {
-            cursor = match action {
+            match action {
                 &UndoAction::DeleteRange(range) => {
                     undo_actions.push(UndoAction::InsertRange(range.0, buffer.delete_range(range)));
-                    range.0
                 }
                 &UndoAction::InsertRange(pos, ref text) => {
                     undo_actions.push(UndoAction::DeleteRange(text.motion_range(pos)));
                     buffer.insert_range(pos, text.clone());
-                    pos
                 }
             };
         }
 
         Change {
             keys: self.keys.clone(),
-            cursor,
+            cursor: self.cursor,
             undo_actions,
         }
     }

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -1,3 +1,4 @@
+pub mod handler;
 pub mod manager;
 
 use crate::input::Key;

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -14,7 +14,7 @@ pub enum UndoAction {
 #[derive(Debug, Clone)]
 pub struct Change {
     /// Where this Change occurred (for redoing, if undone)
-    cursor: CursorPosition,
+    pub cursor: CursorPosition,
 
     /// The Keys that triggered this change
     pub keys: Vec<Key>,

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -4,11 +4,13 @@ use crate::input::Key;
 
 use super::{buffer::CopiedRange, motion::MotionRange, Buffer, CursorPosition};
 
+#[derive(Debug, Clone)]
 pub enum UndoAction {
     DeleteRange(MotionRange),
     InsertRange(CursorPosition, CopiedRange),
 }
 
+#[derive(Debug, Clone)]
 pub struct Change {
     /// Where this Change occurred (for redoing, if undone)
     cursor: CursorPosition,

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -34,13 +34,26 @@ impl Change {
         }
     }
 
-    pub fn undo(&self, buffer: &mut Box<dyn Buffer>) {
+    pub fn undo(&self, buffer: &mut Box<dyn Buffer>) -> CursorPosition {
+        let mut cursor = CursorPosition::default();
+
         for action in self.undo_actions.iter().rev() {
-            match action {
-                &UndoAction::DeleteRange(range) => buffer.delete_range(range),
-                &UndoAction::Insert(pos, ref text) => buffer.insert(pos, text.clone()),
-                &UndoAction::InsertLines(pos, ref lines) => buffer.insert_lines(pos, lines.clone()),
+            cursor = match action {
+                &UndoAction::DeleteRange(range) => {
+                    buffer.delete_range(range);
+                    range.0
+                }
+                &UndoAction::Insert(pos, ref text) => {
+                    buffer.insert(pos, text.clone());
+                    pos
+                }
+                &UndoAction::InsertLines(line, ref lines) => {
+                    buffer.insert_lines(line, lines.clone());
+                    CursorPosition { line, col: 0 }
+                }
             };
         }
+
+        cursor
     }
 }

--- a/src/editing/change/mod.rs
+++ b/src/editing/change/mod.rs
@@ -2,16 +2,11 @@ pub mod manager;
 
 use crate::input::Key;
 
-use super::{
-    motion::MotionRange,
-    text::{TextLine, TextLines},
-    Buffer, CursorPosition,
-};
+use super::{buffer::CopiedRange, motion::MotionRange, Buffer, CursorPosition};
 
 pub enum UndoAction {
     DeleteRange(MotionRange),
-    Insert(CursorPosition, TextLine),
-    InsertLines(usize, TextLines),
+    InsertRange(CursorPosition, CopiedRange),
 }
 
 pub struct Change {
@@ -43,13 +38,9 @@ impl Change {
                     buffer.delete_range(range);
                     range.0
                 }
-                &UndoAction::Insert(pos, ref text) => {
-                    buffer.insert(pos, text.clone());
+                &UndoAction::InsertRange(pos, ref text) => {
+                    buffer.insert_range(pos, text.clone());
                     pos
-                }
-                &UndoAction::InsertLines(line, ref lines) => {
-                    buffer.insert_lines(line, lines.clone());
-                    CursorPosition { line, col: 0 }
                 }
             };
         }

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -1,5 +1,6 @@
 pub mod buffer;
 pub mod buffers;
+pub mod change;
 pub mod ids;
 pub mod layout;
 pub mod motion;

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -10,6 +10,8 @@ pub mod tabpages;
 pub mod text;
 pub mod window;
 
+use std::ops;
+
 pub use buffer::Buffer;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -46,6 +48,18 @@ impl CursorPosition {
         CursorPosition {
             line: self.line,
             col: line_width as u16,
+        }
+    }
+}
+
+impl ops::Add<(usize, u16)> for CursorPosition {
+    type Output = CursorPosition;
+
+    fn add(self, rhs: (usize, u16)) -> CursorPosition {
+        let (lines, cols) = rhs;
+        Self {
+            line: self.line + lines,
+            col: self.col + cols,
         }
     }
 }

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -41,6 +41,13 @@ impl From<SimpleMotionRange> for MotionRange {
     }
 }
 
+impl From<((usize, u16), (usize, u16))> for MotionRange {
+    fn from(simple: ((usize, u16), (usize, u16))) -> Self {
+        let (start, end) = simple;
+        MotionRange(start.into(), end.into(), MotionFlags::NONE)
+    }
+}
+
 pub trait MotionContext {
     fn buffer(&self) -> &Box<dyn Buffer>;
     fn buffer_mut(&mut self) -> &mut Box<dyn Buffer>;

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -146,7 +146,10 @@ pub mod tests {
     use crate::{
         app,
         editing::{
-            buffer::MemoryBuffer, text::TextLine, window::Window, Buffer, HasId, Resizable, Size,
+            buffer::{MemoryBuffer, UndoableBuffer},
+            text::TextLine,
+            window::Window,
+            Buffer, Resizable, Size,
         },
         input::{
             commands::registry::CommandRegistry, completion::CompletableContext,
@@ -334,7 +337,7 @@ pub mod tests {
     pub fn window(s: &'static str) -> TestWindow {
         let s: String = s.into();
         let mut cursor = CursorPosition::default();
-        let mut buffer = MemoryBuffer::new(0);
+        let mut buffer = UndoableBuffer::wrap(Box::new(MemoryBuffer::new(0)));
         let mut non_buffer_lines = 0;
 
         for (index, line) in s.lines().enumerate() {
@@ -364,7 +367,7 @@ pub mod tests {
 
         TestWindow {
             window: Box::new(window),
-            buffer: Box::new(buffer),
+            buffer,
             commands: CommandRegistry::default(),
         }
     }

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -17,6 +17,21 @@ bitflags! {
 
 #[derive(Debug, Clone, Copy)]
 pub struct MotionRange(pub CursorPosition, pub CursorPosition, pub MotionFlags);
+impl MotionRange {
+    pub fn lines(&self) -> (usize, usize) {
+        let &MotionRange(
+            CursorPosition {
+                line: first_line, ..
+            },
+            CursorPosition {
+                line: last_line, ..
+            },
+            ..,
+        ) = self;
+        (first_line, last_line)
+    }
+}
+
 pub type SimpleMotionRange = (CursorPosition, CursorPosition);
 
 impl From<SimpleMotionRange> for MotionRange {
@@ -113,7 +128,7 @@ pub trait Motion {
 
     fn delete_range<T: MotionContext>(&self, context: &mut T) {
         let range = self.range(context);
-        context.buffer_mut().delete_range(range)
+        context.buffer_mut().delete_range(range);
     }
 }
 

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -149,7 +149,7 @@ pub mod tests {
             buffer::{MemoryBuffer, UndoableBuffer},
             text::TextLine,
             window::Window,
-            Buffer, Resizable, Size,
+            Buffer, HasId, Resizable, Size,
         },
         input::{
             commands::registry::CommandRegistry, completion::CompletableContext,
@@ -337,7 +337,7 @@ pub mod tests {
     pub fn window(s: &'static str) -> TestWindow {
         let s: String = s.into();
         let mut cursor = CursorPosition::default();
-        let mut buffer = UndoableBuffer::wrap(Box::new(MemoryBuffer::new(0)));
+        let mut buffer = Box::new(MemoryBuffer::new(0));
         let mut non_buffer_lines = 0;
 
         for (index, line) in s.lines().enumerate() {
@@ -367,7 +367,7 @@ pub mod tests {
 
         TestWindow {
             window: Box::new(window),
-            buffer,
+            buffer: UndoableBuffer::wrap(buffer),
             commands: CommandRegistry::default(),
         }
     }

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -301,7 +301,7 @@ pub mod tests {
         }
 
         fn bufwin(&mut self) -> BufWin {
-            BufWin::new(&mut self.window, &self.buffer)
+            BufWin::new(&mut self.window, &mut self.buffer)
         }
 
         fn cursor(&self) -> crate::editing::CursorPosition {

--- a/src/editing/motion/word.rs
+++ b/src/editing/motion/word.rs
@@ -188,8 +188,7 @@ mod tests {
             "});
 
             // split up the span by deleting a range:
-            ctx.buffer
-                .delete_range(((0, 7).into(), (0, 12).into()).into());
+            ctx.buffer.delete_range(((0, 7), (0, 12)).into());
             ctx.window.cursor = (0, 8).into();
             ctx.assert_visual_match(indoc! {"
                 Take my |land

--- a/src/input/commands/file.rs
+++ b/src/input/commands/file.rs
@@ -42,13 +42,12 @@ declare_commands!(declare_file {
         context.state_mut().echo(format!("\"{}\": {}L, {}B", full_path_string, lines_count, bytes).into());
 
         let buffer_id = {
-            let buffer = context.state_mut().buffers.create();
-            buffer.id()
+            let buf = context.state_mut().buffers.create_mut();
+            buf.append(TextLines::from(lines));
+            buf.set_source(BufferSource::LocalFile(full_path_string.to_string()));
+            buf.changes().clear();
+            buf.id()
         };
-
-        let buf = context.state_mut().buffers.by_id_mut(buffer_id).expect("New buffer did not exist");
-        buf.append(TextLines::from(lines));
-        buf.set_source(BufferSource::LocalFile(full_path_string.to_string()));
 
         context.state_mut().set_current_window_buffer(buffer_id);
 

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -61,6 +61,7 @@ fn common_insert_mode(extra_mappings: Option<KeyTreeNode>) -> VimMode {
         "<esc>" => |ctx| {
             ctx.state_mut().clear_echo();
             ctx.state_mut().current_window_mut().set_inserting(false);
+            ctx.state_mut().current_buffer_mut().end_change();
             CharMotion::Backward(1).apply_cursor(ctx.state_mut());
             Ok(())
          },

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -281,15 +281,17 @@ macro_rules! vim_branches {
             $ctx_name.state_mut().current_bufwin().begin_keys_change($keys);
 
             if let Some(pending_key) = $ctx_name.keymap.pending_linewise_operator_key.take() {
-                if pending_key == $keys.into() {
+                let operator_result = if pending_key == $keys.into() {
                     // execute linewise action directly:
                     let motion_impl = crate::editing::motion::linewise::FullLineMotion;
                     let $motion_name = motion_impl.range($ctx_name.state());
-                    return $body;
+                    $body
                 } else {
                     // different pending operator key; abort
-                    return Ok(());
-                }
+                    Ok(())
+                };
+                $ctx_name.state_mut().current_buffer_mut().end_change();
+                return operator_result;
             }
 
             // no pending linewise op; save a closure for motion use:

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -142,6 +142,12 @@ impl Keymap for VimKeymap {
                 if show_keys {
                     self.keymap.keys_buffer.push(key.clone());
                 }
+                if context.state().current_window().inserting {
+                    context
+                        .state_mut()
+                        .current_buffer_mut()
+                        .push_change_key(key);
+                }
 
                 if let Some(next) = current.children.get(&key) {
                     // TODO timeouts with nested handlers

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -107,7 +107,17 @@ pub fn vim_normal_mode() -> VimMode {
         "u" => |ctx| {
             ctx.state_mut().current_bufwin().undo();
             Ok(())
-         },
+        },
+
+        // TODO redo queue for <ctrl-r>
+
+        "." => |ctx| {
+            if let Some(last) = ctx.state_mut().current_buffer_mut().changes().take_last() {
+                // TODO enqueue keys
+                ctx.state_mut().current_buffer_mut().changes().push(last);
+            }
+            Ok(())
+        },
 
     } + cmd_mode_access()
         + window::mappings()

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -104,6 +104,11 @@ pub fn vim_normal_mode() -> VimMode {
             Ok(())
         },
 
+        "u" => |ctx| {
+            ctx.state_mut().current_bufwin().undo();
+            Ok(())
+         },
+
     } + cmd_mode_access()
         + window::mappings()
         + vim_standard_motions()
@@ -197,6 +202,25 @@ mod tests {
             ctx.feed_vim("D").assert_visual_match(indoc! {"
                 Take my love
                 |
+                Take me where
+            "});
+        }
+    }
+
+    #[cfg(test)]
+    mod u {
+        use super::*;
+
+        #[test]
+        fn undo_restores_cursor() {
+            let ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.feed_vim("Dku").assert_visual_match(indoc! {"
+                Take my love
+                |Take my land
                 Take me where
             "});
         }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -234,6 +234,41 @@ mod tests {
         use super::*;
 
         #[test]
+        fn undo_empty() {
+            let mut ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.buffer.changes().clear();
+            ctx.feed_vim("u").assert_visual_match(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+        }
+
+        #[test]
+        fn undo_line_appends() {
+            let mut ctx = window("");
+            ctx.buffer.append("Take my love".into());
+            ctx.buffer.append("Take my land".into());
+            ctx.buffer.append("Take me where".into());
+            ctx.window.cursor = (2, 12).into();
+
+            ctx = ctx.feed_vim("u");
+            ctx.render_at_own_size();
+
+            ctx = ctx.feed_vim("u");
+            ctx.render_at_own_size();
+
+            ctx = ctx.feed_vim("u");
+            ctx.render_at_own_size();
+
+            ctx.feed_vim("u").assert_visual_match("");
+        }
+
+        #[test]
         fn undo_restores_cursor() {
             let ctx = window(indoc! {"
                 Take my love

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -251,21 +251,28 @@ mod tests {
         #[test]
         fn undo_line_appends() {
             let mut ctx = window("");
+            ctx.window.size = (20, 2).into();
             ctx.buffer.append("Take my love".into());
             ctx.buffer.append("Take my land".into());
             ctx.buffer.append("Take me where".into());
             ctx.window.cursor = (2, 12).into();
 
             ctx = ctx.feed_vim("u");
-            ctx.render_at_own_size();
+            ctx.assert_visual_match(indoc! {"
+                Take my love
+                |Take my land
+            "});
+
+            ctx = ctx.feed_vim("u");
+            ctx.assert_visual_match(indoc! {"
+                ~
+                |Take my love
+            "});
 
             ctx = ctx.feed_vim("u");
             ctx.render_at_own_size();
 
-            ctx = ctx.feed_vim("u");
-            ctx.render_at_own_size();
-
-            ctx.feed_vim("u").assert_visual_match("");
+            ctx.feed_vim("u").render_at_own_size();
         }
 
         #[test]

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -53,17 +53,18 @@ fn cmd_mode_access() -> KeyTreeNode {
 pub fn vim_normal_mode() -> VimMode {
     let mappings = vim_tree! {
         "a" => |ctx| {
-            ctx.state_mut().current_window_mut().set_inserting(true);
+            ctx.state_mut().current_bufwin().begin_insert_change("a");
             CharMotion::Forward(1).apply_cursor(ctx.state_mut());
             Ok(())
         },
         "A" => |ctx| {
-            ctx.state_mut().current_window_mut().set_inserting(true);
+            ctx.state_mut().current_bufwin().begin_insert_change("A");
             ToLineEndMotion.apply_cursor(ctx.state_mut());
             Ok(())
         },
 
         "c" => operator |ctx, motion| {
+            ctx.state_mut().current_bufwin().begin_insert_change("c");
             ctx.state_mut().current_buffer_mut().delete_range(motion);
 
             let MotionRange(start, _, flags) = motion;
@@ -74,10 +75,10 @@ pub fn vim_normal_mode() -> VimMode {
                 ctx.state_mut().current_buffer_mut().insert_lines(start.line, TextLine::from("").into());
             }
 
-            ctx.state_mut().current_window_mut().set_inserting(true);
             Ok(())
         },
         "C" => |ctx| {
+            ctx.state_mut().current_bufwin().begin_insert_change("C");
             let range = ToLineEndMotion.range(ctx.state());
             ctx.state_mut().current_buffer_mut().delete_range(range);
             ctx.state_mut().current_window_mut().set_inserting(true);
@@ -95,11 +96,11 @@ pub fn vim_normal_mode() -> VimMode {
         },
 
         "i" => |ctx| {
-            ctx.state_mut().current_window_mut().set_inserting(true);
+            ctx.state_mut().current_bufwin().begin_insert_change("i");
             Ok(())
         },
         "I" => |ctx| {
-            ctx.state_mut().current_window_mut().set_inserting(true);
+            ctx.state_mut().current_bufwin().begin_insert_change("I");
             ToLineStartMotion.apply_cursor(ctx.state_mut());
             Ok(())
         },

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -105,11 +105,23 @@ pub fn vim_normal_mode() -> VimMode {
         },
 
         "u" => |ctx| {
-            ctx.state_mut().current_bufwin().undo();
+            if ctx.state_mut().current_bufwin().undo() {
+                // TODO more info?
+                ctx.state_mut().echo_str("1 change; older");
+            } else {
+                ctx.state_mut().echo_str("Already at oldest change");
+            }
             Ok(())
         },
-
-        // TODO redo queue for <ctrl-r>
+        "<ctrl-r>" => |ctx| {
+            if ctx.state_mut().current_bufwin().redo() {
+                // TODO more info?
+                ctx.state_mut().echo_str("1 change; newer");
+            } else {
+                ctx.state_mut().echo_str("Already at newest change");
+            }
+            Ok(())
+        },
 
         "." => |ctx| {
             if let Some(last) = ctx.state_mut().current_buffer_mut().changes().take_last() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,6 @@ fn main() -> Result<(), io::Error> {
 
     if let Some(mut bottom_win) = app.state.bufwin_by_id(bottom_id) {
         bottom_win.scroll_lines(1);
-        bottom_win.window.set_inserting(true);
         bottom_win.window.cursor = CursorPosition { line: 1, col: 0 }
     }
 


### PR DESCRIPTION
- WIP: begin work to track changes to support undo/redo and repeat
- Continue incremental work on ChangeManager
- Begin implementing undo as a wrapper on top of any Buffer
- Add preliminary support for capturing the deleted range
- Begin testing Change.undo
- Fix single-line partial insert_range handling
- Handle undoing range insertions
- Add tests for undo via remaining buffer editing ops
- Reorganize; move change interactions into a utility struct
- Minor cleanup
- Add `u` undo map
- Stub support for repeating a change via .
- Support redo!
- Ensure a newly-read buffer has no undo history
- Improve reliability of undo application
- Improve cursor handling when undoing
