### PR TITLE
Improve handling of exclusive motions

### DIFF
--- a/src/editing/motion/linewise.rs
+++ b/src/editing/motion/linewise.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use crate::editing::CursorPosition;
 
-use super::Motion;
+use super::{Motion, MotionFlags};
 
 /// Motion that moves the cursor to the start of the current line
 pub struct ToLineStartMotion;
@@ -45,8 +45,8 @@ impl Motion for ToLastLineOfBufferMotion {
 /// Motion that selects the entire current line
 pub struct FullLineMotion;
 impl Motion for FullLineMotion {
-    fn is_linewise(&self) -> bool {
-        true
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::LINEWISE
     }
 
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
@@ -57,8 +57,8 @@ impl Motion for FullLineMotion {
 /// Motion to move down one line
 pub struct DownLineMotion;
 impl Motion for DownLineMotion {
-    fn is_linewise(&self) -> bool {
-        true
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::LINEWISE
     }
 
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
@@ -88,8 +88,8 @@ impl Motion for DownLineMotion {
 /// Motion to move up one line
 pub struct UpLineMotion;
 impl Motion for UpLineMotion {
-    fn is_linewise(&self) -> bool {
-        true
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::LINEWISE
     }
 
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
@@ -114,8 +114,8 @@ impl Motion for UpLineMotion {
 
 pub struct ToFirstLineMotion;
 impl Motion for ToFirstLineMotion {
-    fn is_linewise(&self) -> bool {
-        true
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::LINEWISE
     }
 
     fn destination<T: super::MotionContext>(&self, _: &T) -> CursorPosition {
@@ -125,8 +125,8 @@ impl Motion for ToFirstLineMotion {
 
 pub struct ToLastLineMotion;
 impl Motion for ToLastLineMotion {
-    fn is_linewise(&self) -> bool {
-        true
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::LINEWISE
     }
 
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -11,7 +11,8 @@ use super::{window::Window, Buffer, CursorPosition};
 bitflags! {
     pub struct MotionFlags: u8 {
         const NONE = 0;
-        const LINEWISE = 0b01;
+        const LINEWISE  = 0b01;
+        const EXCLUSIVE = 0b10;
     }
 }
 
@@ -90,23 +91,16 @@ impl<'a, T: MotionContext> MotionContext for PositionedMotionContext<'a, T> {
 
 pub trait Motion {
     fn destination<T: MotionContext>(&self, context: &T) -> CursorPosition;
-    fn is_linewise(&self) -> bool {
-        false
-    }
 
     fn flags(&self) -> MotionFlags {
-        let mut flags = MotionFlags::NONE;
-        if self.is_linewise() {
-            flags |= MotionFlags::LINEWISE;
-        }
-        flags
+        MotionFlags::NONE
     }
 
     fn range<T: MotionContext>(&self, context: &T) -> MotionRange {
         let start = context.cursor();
         let end = self.destination(context);
-        let linewise = self.is_linewise();
         let flags = self.flags();
+        let linewise = flags.contains(MotionFlags::LINEWISE);
 
         if linewise && end < start {
             MotionRange(

--- a/src/editing/motion/word.rs
+++ b/src/editing/motion/word.rs
@@ -1,6 +1,6 @@
 use crate::editing::CursorPosition;
 
-use super::{char::CharMotion, linewise::LineCrossing, Motion};
+use super::{char::CharMotion, linewise::LineCrossing, Motion, MotionFlags};
 
 pub fn is_big_word_boundary(ch: &str) -> bool {
     ch == " "
@@ -53,6 +53,10 @@ impl<T> Motion for WordMotion<T>
 where
     T: Fn(&str) -> bool,
 {
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::EXCLUSIVE
+    }
+
     fn destination<C: super::MotionContext>(&self, context: &C) -> CursorPosition {
         if context.buffer().lines_count() == 0 {
             return context.cursor();

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -104,6 +104,7 @@ pub fn vim_normal_mode() -> VimMode {
 
         "d" => operator |ctx, motion| {
             ctx.state_mut().current_buffer_mut().delete_range(motion);
+            ctx.state_mut().current_window_mut().cursor = ctx.state().current_window().clamp_cursor(ctx.state().current_buffer(), motion.0);
             Ok(())
         },
         "D" => |ctx| {
@@ -265,6 +266,19 @@ mod tests {
                 ~
                 Take my love
                 |Take me where
+            "});
+        }
+
+        #[test]
+        fn follows_exclusive_line_cross_exception() {
+            // see :help exclusive in vim
+            let ctx = window(indoc! {"
+                Take my |love
+                Take my land
+            "});
+            ctx.feed_vim("dw").assert_visual_match(indoc! {"
+                Take my| 
+                Take my land
             "});
         }
 


### PR DESCRIPTION
Fixes #28

- Replace Motion::is_linewise() with flags()
- Normalize exclusive motions per The Rules
