### PR TITLE
Add `feed_keys` to `KeyHandlerContext`

### DIFF
--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use crate::input::{Key, KeyError, KeySource, Keymap};
+use crate::input::{source::memory::MemoryKeySource, Key, KeyError, KeySource, Keymap};
 use crate::ui::{UiEvent, UiEvents, UI};
 use crate::{
     app::{self, App},
@@ -13,11 +13,17 @@ use super::jobs::Jobs;
 struct AppKeySource<U: UI, UE: UiEvents> {
     app: App<U>,
     events: UE,
+    fed: MemoryKeySource,
 }
 
 impl<U: UI, UE: UiEvents> KeySource for AppKeySource<U, UE> {
     fn poll_key(&mut self, duration: Duration) -> Result<bool, KeyError> {
         self.app.render();
+
+        if self.fed.poll_key(duration)? {
+            return Ok(true);
+        }
+
         match self.events.poll_event(duration) {
             Ok(Some(UiEvent::Key(_))) => Ok(true),
             Ok(_) => Ok(false),
@@ -26,6 +32,11 @@ impl<U: UI, UE: UiEvents> KeySource for AppKeySource<U, UE> {
     }
 
     fn next_key(&mut self) -> Result<Option<Key>, KeyError> {
+        // if there are fed keys pending, return those immediately
+        if self.fed.poll_key(Duration::from_millis(0))? {
+            return self.fed.next_key();
+        }
+
         let mut dirty = true;
         loop {
             loop {
@@ -57,6 +68,10 @@ impl<U: UI, UE: UiEvents> KeySource for AppKeySource<U, UE> {
             dirty = true;
         }
     }
+
+    fn feed_keys(&mut self, keys: Vec<Key>) {
+        self.fed.feed_keys(keys);
+    }
 }
 
 impl<U: UI, UE: UiEvents> KeymapContext for AppKeySource<U, UE> {
@@ -74,7 +89,11 @@ where
     UE: UiEvents,
     KM: Keymap,
 {
-    let mut app_keys = AppKeySource { app, events };
+    let mut app_keys = AppKeySource {
+        app,
+        events,
+        fed: MemoryKeySource::empty(),
+    };
 
     loop {
         if let Err(e) = map.process(&mut app_keys) {

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -156,7 +156,7 @@ pub mod tests {
     use std::{cmp::max, time::Duration};
 
     use crate::{
-        app,
+        app, delegate_keysource,
         editing::{
             buffer::{MemoryBuffer, UndoableBuffer},
             text::TextLine,
@@ -191,16 +191,7 @@ pub mod tests {
     }
 
     impl KeySource for TestKeymapContext {
-        fn poll_key(
-            &mut self,
-            timeout: std::time::Duration,
-        ) -> Result<bool, crate::input::KeyError> {
-            self.keys.poll_key(timeout)
-        }
-
-        fn next_key(&mut self) -> Result<Option<crate::input::Key>, crate::input::KeyError> {
-            self.keys.next_key()
-        }
+        delegate_keysource!(keys);
     }
 
     pub struct TestWindow {

--- a/src/input/commands/mod.rs
+++ b/src/input/commands/mod.rs
@@ -7,12 +7,14 @@ pub mod window;
 
 use std::time::Duration;
 
+use crate::delegate_keysource;
+
 use self::{
     colors::declare_colors, connection::declare_connection, core::declare_core, file::declare_file,
     registry::CommandRegistry, window::declare_window,
 };
 
-use super::{maps::KeyResult, Key, KeyError, KeySource, KeymapContext};
+use super::{maps::KeyResult, KeySource, KeymapContext};
 
 pub type CommandHandler = dyn Fn(&mut CommandHandlerContext<'_>) -> KeyResult;
 
@@ -63,12 +65,7 @@ impl KeymapContext for CommandHandlerContext<'_> {
 }
 
 impl KeySource for CommandHandlerContext<'_> {
-    fn poll_key(&mut self, timeout: Duration) -> Result<bool, KeyError> {
-        self.context.poll_key(timeout)
-    }
-    fn next_key(&mut self) -> Result<Option<Key>, KeyError> {
-        self.context.next_key()
-    }
+    delegate_keysource!(context);
 }
 
 pub fn create_builtin_commands() -> CommandRegistry {

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use crate::delegate_keysource;
+
 use super::{Key, KeyError, KeySource, KeymapContext};
 
 pub mod actions;
@@ -21,12 +23,7 @@ impl<'a, T> KeymapContext for KeyHandlerContext<'a, T> {
 }
 
 impl<'a, T> KeySource for KeyHandlerContext<'a, T> {
-    fn poll_key(&mut self, timeout: Duration) -> Result<bool, KeyError> {
-        self.context.poll_key(timeout)
-    }
-    fn next_key(&mut self) -> Result<Option<Key>, KeyError> {
-        self.context.next_key()
-    }
+    delegate_keysource! { context }
 }
 
 pub type KeyResult = Result<(), KeyError>;

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -9,7 +9,7 @@ pub mod vim;
 
 pub struct KeyHandlerContext<'a, T> {
     context: Box<&'a mut dyn KeymapContext>,
-    keymap: &'a mut T,
+    pub keymap: &'a mut T,
     key: Key,
 }
 

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -1,4 +1,4 @@
-use super::{tree::KeyTreeNode, VimKeymapState, VimMode};
+use super::{tree::KeyTreeNode, VimKeymap, VimMode};
 use crate::{
     editing::motion::{
         char::CharMotion,
@@ -72,7 +72,7 @@ fn common_insert_mode(extra_mappings: Option<KeyTreeNode>) -> VimMode {
     }
 
     VimMode::new("i", mappings).on_default(key_handler!(
-        VimKeymapState | ctx | {
+        VimKeymap | ctx | {
             match ctx.key.code {
                 KeyCode::Char(c) => {
                     ctx.state_mut().type_at_cursor(c);

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -1,4 +1,4 @@
-use crate::input::maps::vim::VimKeymapState;
+use crate::input::maps::vim::VimKeymap;
 use crate::input::KeymapContext;
 use crate::vim_tree;
 use crate::{

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,18 +1,16 @@
 mod window;
 
-use std::time::Duration;
-
 use crate::input::{
-    commands::CommandHandlerContext, maps::KeyResult, KeyError, KeySource, Keymap, KeymapContext,
-    KeymapContextWithKeys,
+    commands::CommandHandlerContext,
+    maps::{feed_keys, KeyResult},
+    KeyError, KeymapContext,
 };
-use crate::input::{source::memory::MemoryKeySource, Key};
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
     editing::motion::{Motion, MotionFlags, MotionRange},
+    editing::text::TextLine,
 };
-use crate::{editing::text::TextLine, input::maps::KeyHandlerContext};
 use crate::{key_handler, vim_tree};
 
 use super::{
@@ -202,20 +200,6 @@ pub fn vim_normal_mode() -> VimMode {
             Ok(())
         }
     ))
-}
-
-fn feed_keys(ctx: KeyHandlerContext<VimKeymap>, keys: Vec<Key>) -> KeyResult {
-    let source = MemoryKeySource::from(keys);
-
-    let mut context = KeymapContextWithKeys {
-        base: ctx.context,
-        keys: source,
-    };
-    while context.keys.poll_key(Duration::from_millis(0))? {
-        ctx.keymap.process(&mut context)?;
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,10 +1,6 @@
 mod window;
 
-use crate::input::{
-    commands::CommandHandlerContext,
-    maps::{feed_keys, KeyResult},
-    KeyError, KeymapContext,
-};
+use crate::input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext};
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
@@ -184,7 +180,7 @@ pub fn vim_normal_mode() -> VimMode {
             if let Some(last) = ctx.state_mut().current_buffer_mut().changes().take_last() {
                 let keys = last.keys.clone();
                 ctx.state_mut().current_buffer_mut().changes().push(last);
-                feed_keys(ctx, keys)?
+                ctx.feed_keys(keys)?;
             }
             Ok(())
         },

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,6 +1,7 @@
 mod window;
 
 use crate::editing::text::TextLine;
+use crate::input::KeySource;
 use crate::input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext};
 use crate::{
     editing::motion::char::CharMotion,
@@ -178,7 +179,7 @@ pub fn vim_normal_mode() -> VimMode {
 
             ctx.state_mut().request_redraw();
             if let Some(last) = ctx.state_mut().current_buffer_mut().changes().take_last() {
-                // TODO enqueue keys
+                ctx.feed_keys(last.keys.clone());
                 ctx.state_mut().current_buffer_mut().changes().push(last);
             }
             Ok(())

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -40,7 +40,7 @@ fn cmd_mode_access() -> KeyTreeNode {
             ctx.state_mut().clear_echo();
             ctx.state_mut().prompt.activate(":".into());
 
-            ctx.keymap.keymap.push_mode(VimPromptConfig{
+            ctx.keymap.push_mode(VimPromptConfig{
                 prompt: ":".into(),
                 handler: Box::new(handle_command),
                 // TODO autocomplete
@@ -192,7 +192,7 @@ pub fn vim_normal_mode() -> VimMode {
 
     VimMode::new("n", mappings).on_default(key_handler!(
         VimKeymap | ?mut ctx | {
-            ctx.keymap.keymap.reset();
+            ctx.keymap.reset();
             Ok(())
         }
     ))

--- a/src/input/maps/vim/normal/window.rs
+++ b/src/input/maps/vim/normal/window.rs
@@ -1,4 +1,4 @@
-use crate::input::maps::vim::VimKeymapState;
+use crate::input::maps::vim::VimKeymap;
 use crate::input::maps::{vim::tree::KeyTreeNode, KeyHandlerContext};
 use crate::input::KeymapContext;
 use crate::vim_tree;
@@ -23,7 +23,7 @@ pub fn mappings() -> KeyTreeNode {
     }
 }
 
-fn focus(mut ctx: KeyHandlerContext<VimKeymapState>, direction: FocusDirection) -> KeyResult {
+fn focus(mut ctx: KeyHandlerContext<VimKeymap>, direction: FocusDirection) -> KeyResult {
     ctx.state_mut().current_tab_mut().move_focus(direction);
     Ok(())
 }

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -55,14 +55,14 @@ fn mappings(config: VimPromptConfig) -> KeyTreeNode {
     let prompt_len = config.prompt.len();
     vim_tree! {
         "<esc>" => |ctx| {
-            ctx.keymap.keymap.mode_stack.pop();
+            ctx.keymap.mode_stack.pop();
             ctx.state_mut().prompt.clear();
             Ok(())
          },
 
          "<cr>" => move |ctx| {
              let input = ctx.state().prompt.buffer.get_contents()[prompt_len..].to_string();
-             ctx.keymap.keymap.mode_stack.pop();
+             ctx.keymap.mode_stack.pop();
              ctx.state_mut().prompt.clear();
 
              // submit to handler

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -7,7 +7,7 @@ use crate::{
     key_handler, vim_tree,
 };
 
-use super::{insert::vim_insert_mappings, tree::KeyTreeNode, VimKeymapState, VimMode};
+use super::{insert::vim_insert_mappings, tree::KeyTreeNode, VimKeymap, VimMode};
 
 pub struct VimPromptConfig {
     pub prompt: String,
@@ -22,7 +22,7 @@ impl Into<VimMode> for VimPromptConfig {
 
         VimMode::new(mode_id.clone(), vim_insert_mappings() + mappings(self))
             .on_default(key_handler!(
-                VimKeymapState | ctx | {
+                VimKeymap | ctx | {
                     match ctx.key.code {
                         KeyCode::Char(c) => {
                             ctx.state_mut().type_at_cursor(c);
@@ -34,7 +34,7 @@ impl Into<VimMode> for VimPromptConfig {
                 }
             ))
             .on_after(key_handler!(
-                VimKeymapState move | ctx | {
+                VimKeymap move | ctx | {
                     let b = &ctx.state().prompt.buffer;
                     if b.is_empty() || !b.get(0).starts_with(&prompt) {
                         ctx.state_mut().prompt.buffer.insert((0, 0).into(), prompt.clone().into());
@@ -55,14 +55,14 @@ fn mappings(config: VimPromptConfig) -> KeyTreeNode {
     let prompt_len = config.prompt.len();
     vim_tree! {
         "<esc>" => |ctx| {
-            ctx.keymap.mode_stack.pop();
+            ctx.keymap.keymap.mode_stack.pop();
             ctx.state_mut().prompt.clear();
             Ok(())
          },
 
          "<cr>" => move |ctx| {
              let input = ctx.state().prompt.buffer.get_contents()[prompt_len..].to_string();
-             ctx.keymap.mode_stack.pop();
+             ctx.keymap.keymap.mode_stack.pop();
              ctx.state_mut().prompt.clear();
 
              // submit to handler

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,7 +4,9 @@ pub mod keys;
 pub mod maps;
 pub mod source;
 
-use std::{io, time::Duration};
+pub use source::KeySource;
+
+use std::io;
 
 pub type KeyCode = crossterm::event::KeyCode;
 pub type KeyModifiers = crossterm::event::KeyModifiers;
@@ -71,11 +73,6 @@ impl From<url::ParseError> for KeyError {
     fn from(error: url::ParseError) -> Self {
         KeyError::InvalidInput(error.to_string())
     }
-}
-
-pub trait KeySource {
-    fn poll_key(&mut self, timeout: Duration) -> Result<bool, KeyError>;
-    fn next_key(&mut self) -> Result<Option<Key>, KeyError>;
 }
 
 pub trait KeymapContext: KeySource {

--- a/src/input/source/memory.rs
+++ b/src/input/source/memory.rs
@@ -1,4 +1,5 @@
-use crate::input::{keys::KeysParsable, Key, KeySource};
+use super::KeySource;
+use crate::input::{keys::KeysParsable, Key};
 
 /// A MemoryKeySource provides a fixed sequence of keys
 /// from memory

--- a/src/input/source/memory.rs
+++ b/src/input/source/memory.rs
@@ -22,6 +22,12 @@ impl MemoryKeySource {
     }
 }
 
+impl From<Vec<Key>> for MemoryKeySource {
+    fn from(keys: Vec<Key>) -> Self {
+        Self { keys }
+    }
+}
+
 impl KeySource for MemoryKeySource {
     fn poll_key(&mut self, _timeout: std::time::Duration) -> Result<bool, crate::input::KeyError> {
         Ok(!self.keys.is_empty())

--- a/src/input/source/memory.rs
+++ b/src/input/source/memory.rs
@@ -8,12 +8,6 @@ pub struct MemoryKeySource {
 }
 
 impl MemoryKeySource {
-    pub fn empty() -> Self {
-        Self {
-            keys: Vec::default(),
-        }
-    }
-
     #[allow(unused)]
     pub fn from_keys<T: KeysParsable>(keys: T) -> Self {
         MemoryKeySource {
@@ -39,9 +33,5 @@ impl KeySource for MemoryKeySource {
         }
 
         Ok(Some(self.keys.remove(0)))
-    }
-
-    fn feed_keys(&mut self, keys: Vec<Key>) {
-        self.keys.splice(0..0, keys);
     }
 }

--- a/src/input/source/memory.rs
+++ b/src/input/source/memory.rs
@@ -8,6 +8,12 @@ pub struct MemoryKeySource {
 }
 
 impl MemoryKeySource {
+    pub fn empty() -> Self {
+        Self {
+            keys: Vec::default(),
+        }
+    }
+
     #[allow(unused)]
     pub fn from_keys<T: KeysParsable>(keys: T) -> Self {
         MemoryKeySource {
@@ -27,5 +33,9 @@ impl KeySource for MemoryKeySource {
         }
 
         Ok(Some(self.keys.remove(0)))
+    }
+
+    fn feed_keys(&mut self, keys: Vec<Key>) {
+        self.keys.splice(0..0, keys);
     }
 }

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -8,12 +8,7 @@ pub trait KeySource {
     fn poll_key(&mut self, timeout: Duration) -> Result<bool, KeyError>;
     fn next_key(&mut self) -> Result<Option<Key>, KeyError>;
 
-    fn can_feed(&self) -> bool {
-        false
-    }
-    fn feed_keys(&self, _keys: Vec<Key>) {
-        panic!("KeySource does not support feed_keys");
-    }
+    fn feed_keys(&mut self, keys: Vec<Key>);
 }
 
 #[macro_export]
@@ -26,10 +21,7 @@ macro_rules! delegate_keysource {
             self.$base_source.next_key()
         }
 
-        fn can_feed(&self) -> bool {
-            self.$base_source.can_feed()
-        }
-        fn feed_keys(&self, keys: Vec<crate::input::Key>) {
+        fn feed_keys(&mut self, keys: Vec<crate::input::Key>) {
             self.$base_source.feed_keys(keys)
         }
     };

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -7,8 +7,6 @@ use super::{Key, KeyError};
 pub trait KeySource {
     fn poll_key(&mut self, timeout: Duration) -> Result<bool, KeyError>;
     fn next_key(&mut self) -> Result<Option<Key>, KeyError>;
-
-    fn feed_keys(&mut self, keys: Vec<Key>);
 }
 
 #[macro_export]
@@ -19,10 +17,6 @@ macro_rules! delegate_keysource {
         }
         fn next_key(&mut self) -> Result<Option<crate::input::Key>, crate::input::KeyError> {
             self.$base_source.next_key()
-        }
-
-        fn feed_keys(&mut self, keys: Vec<crate::input::Key>) {
-            self.$base_source.feed_keys(keys)
         }
     };
 }

--- a/src/input/source/mod.rs
+++ b/src/input/source/mod.rs
@@ -1,1 +1,36 @@
 pub mod memory;
+
+use std::time::Duration;
+
+use super::{Key, KeyError};
+
+pub trait KeySource {
+    fn poll_key(&mut self, timeout: Duration) -> Result<bool, KeyError>;
+    fn next_key(&mut self) -> Result<Option<Key>, KeyError>;
+
+    fn can_feed(&self) -> bool {
+        false
+    }
+    fn feed_keys(&self, _keys: Vec<Key>) {
+        panic!("KeySource does not support feed_keys");
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_keysource {
+    ($base_source:ident) => {
+        fn poll_key(&mut self, timeout: Duration) -> Result<bool, crate::input::KeyError> {
+            self.$base_source.poll_key(timeout)
+        }
+        fn next_key(&mut self) -> Result<Option<crate::input::Key>, crate::input::KeyError> {
+            self.$base_source.next_key()
+        }
+
+        fn can_feed(&self) -> bool {
+            self.$base_source.can_feed()
+        }
+        fn feed_keys(&self, keys: Vec<crate::input::Key>) {
+            self.$base_source.feed_keys(keys)
+        }
+    };
+}

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -3,7 +3,7 @@ use std::{io, time::Duration};
 use crossterm::{event::Event, event::KeyCode, event::KeyModifiers, ErrorKind};
 
 use crate::{
-    input::{Key, KeyError, KeySource},
+    input::Key,
     ui::{UiEvent, UiEvents},
 };
 
@@ -93,26 +93,6 @@ impl UiEvents for TuiEvents {
             Ok(Event::Key(key)) => Ok(UiEvent::Key(key.into())),
             Ok(Event::Mouse(_)) => Ok(UiEvent::Redraw),
             Err(e) => Err(wrap_as_io(e)),
-        }
-    }
-}
-
-impl KeySource for TuiEvents {
-    fn poll_key(&mut self, duration: Duration) -> Result<bool, KeyError> {
-        match self.poll_event(duration) {
-            Ok(Some(UiEvent::Key(_))) => Ok(true),
-            Ok(_) => Ok(false),
-            Err(e) => Err(e.into()),
-        }
-    }
-
-    fn next_key(&mut self) -> Result<Option<Key>, KeyError> {
-        loop {
-            match self.next_event() {
-                Ok(UiEvent::Key(key)) => return Ok(Some(key)),
-                Err(e) => return Err(e.into()),
-                _ => {}
-            }
         }
     }
 }


### PR DESCRIPTION
We can now feed keys directly into the keymap! We should be able to handle remap/no remap fairly easily now, by passing a boolean to `process()`

Closes #29 