### PR TITLE
Refactor :q to actually close windows

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -136,15 +136,16 @@ impl AppState {
         self.echo_buffer.append(text);
     }
 
-    pub fn echom(&mut self, text: TextLines) {
-        for line in &text.lines {
-            crate::info!("{}", line.to_string());
-        }
-        self.echo(text);
-    }
-
     pub fn echo_str(&mut self, text: &'static str) {
         self.echo(text.into());
+    }
+
+    pub fn echom<T: Into<TextLines>>(&mut self, text: T) {
+        let lines = text.into();
+        for line in &lines.lines {
+            crate::info!("{}", line.to_string());
+        }
+        self.echo(lines);
     }
 
     // ======= keymap conveniences ============================

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -44,7 +44,7 @@ impl Connections {
         self.all.iter_mut().find(|conn| conn.id() == id)
     }
 
-    pub fn buffer_to_id(&mut self, buffer_id: Id) -> Option<Id> {
+    pub fn buffer_to_id(&self, buffer_id: Id) -> Option<Id> {
         self.buffer_to_connection.get(&buffer_id).cloned()
     }
 

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -17,7 +17,7 @@ use super::{
     motion::{MotionFlags, MotionRange},
     source::BufferSource,
     text::{EditableLine, TextLine, TextLines},
-    CursorPosition, HasId,
+    CursorPosition, HasId, Id,
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -113,6 +113,11 @@ pub trait Buffer: HasId + Send + Sync {
     fn push_change_key(&mut self, _key: Key) {}
     fn end_change(&mut self) {}
 
+    fn is_modified(&self) -> bool {
+        // TODO
+        false
+    }
+
     //
     // Convenience methods, using the core interface above:
     //
@@ -158,6 +163,14 @@ pub trait Buffer: HasId + Send + Sync {
             Some(self.get(line_index))
         } else {
             None
+        }
+    }
+
+    fn connection_buffer_id(&self) -> Option<Id> {
+        match self.source() {
+            &BufferSource::Connection(_) => Some(self.id()),
+            &BufferSource::ConnectionInputForBuffer(id) => Some(id),
+            _ => None,
         }
     }
 

--- a/src/editing/layout/linear.rs
+++ b/src/editing/layout/linear.rs
@@ -204,6 +204,24 @@ impl Layout for LinearLayout {
 }
 
 impl SplitableLayout for LinearLayout {
+    fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn close_window(&mut self, win_id: Id) {
+        if let Some(idx) = self.index_of_window(win_id) {
+            let mut remove_entry = true;
+            if let Some(splittable) = self.entries[idx].into_splittable() {
+                splittable.close_window(win_id);
+                remove_entry = splittable.len() == 0;
+            }
+
+            if remove_entry {
+                self.entries.remove(idx);
+            }
+        }
+    }
+
     fn hsplit(&mut self, current_id: Id, win: Box<Window>) {
         self.split(current_id, win, LayoutDirection::Vertical);
     }

--- a/src/editing/layout/mod.rs
+++ b/src/editing/layout/mod.rs
@@ -34,7 +34,9 @@ pub trait Layout: Renderable + Resizable {
 }
 
 pub trait SplitableLayout {
+    fn len(&self) -> usize;
     fn hsplit(&mut self, current_id: Id, win: Box<Window>);
     fn vsplit(&mut self, current_id: Id, win: Box<Window>);
+    fn close_window(&mut self, win_id: Id);
     fn replace_window(&mut self, win_id: Id, layout: Box<dyn Layout>);
 }

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -195,9 +195,9 @@ pub mod tests {
 
     use super::*;
 
-    struct TestKeymapContext {
-        keys: MemoryKeySource,
-        state: app::State,
+    pub struct TestKeymapContext {
+        pub keys: MemoryKeySource,
+        pub state: app::State,
     }
 
     impl KeymapContext for TestKeymapContext {

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -184,8 +184,10 @@ pub mod tests {
             Buffer, HasId, Resizable, Size,
         },
         input::{
-            commands::registry::CommandRegistry, completion::CompletableContext,
-            source::memory::MemoryKeySource, KeySource, Keymap, KeymapContext,
+            commands::{registry::CommandRegistry, CommandHandlerContext},
+            completion::CompletableContext,
+            source::memory::MemoryKeySource,
+            KeySource, Keymap, KeymapContext,
         },
         tui::{
             rendering::display::tests::TestableDisplay, Display, LayoutContext, RenderContext,
@@ -196,8 +198,27 @@ pub mod tests {
     use super::*;
 
     pub struct TestKeymapContext {
-        pub keys: MemoryKeySource,
-        pub state: app::State,
+        keys: MemoryKeySource,
+        state: app::State,
+    }
+
+    impl TestKeymapContext {
+        pub fn empty() -> TestKeymapContext {
+            TestKeymapContext::from_keys("")
+        }
+        pub fn from_keys(keys: &'static str) -> TestKeymapContext {
+            TestKeymapContext {
+                state: app::State::default(),
+                keys: MemoryKeySource::from_keys(keys),
+            }
+        }
+
+        pub fn command_context(&mut self, input: &'static str) -> CommandHandlerContext {
+            CommandHandlerContext {
+                context: Box::new(self),
+                input: input.to_string(),
+            }
+        }
     }
 
     impl KeymapContext for TestKeymapContext {

--- a/src/editing/tabpage.rs
+++ b/src/editing/tabpage.rs
@@ -63,8 +63,23 @@ impl Tabpage {
         self.layout.by_id_mut(id)
     }
 
+    pub fn has_edit_windows(&self) -> bool {
+        // TODO ?
+        self.layout.len() > 0
+    }
+
     pub fn windows_for_buffer(&mut self, buffer_id: Id) -> impl Iterator<Item = &mut Box<Window>> {
         self.layout.windows_for_buffer(buffer_id)
+    }
+
+    pub fn close_window(&mut self, win_id: Id) {
+        self.layout.close_window(win_id);
+        if self.current == win_id {
+            if let Some(next_focus) = self.layout.first_focus(FocusDirection::Down) {
+                self.current = next_focus;
+                self.by_id_mut(next_focus).unwrap().set_focused(true);
+            }
+        }
     }
 
     pub fn replace_window(&mut self, win_id: Id, layout: Box<dyn Layout>) {

--- a/src/editing/tabpages.rs
+++ b/src/editing/tabpages.rs
@@ -22,9 +22,19 @@ impl Tabpages {
         self.all.len()
     }
 
+    pub fn containing_buffer_mut(&mut self, buffer_id: usize) -> Option<&mut Box<Tabpage>> {
+        for tabpage in &mut self.all {
+            if tabpage.windows_for_buffer(buffer_id).count() > 0 {
+                return Some(tabpage);
+            }
+        }
+
+        None
+    }
+
     pub fn containing_window_mut(&mut self, window_id: usize) -> Option<&mut Box<Tabpage>> {
         for tabpage in &mut self.all {
-            if let Some(_) = tabpage.by_id(window_id) {
+            if tabpage.by_id(window_id).is_some() {
                 return Some(tabpage);
             }
         }
@@ -46,6 +56,10 @@ impl Tabpages {
 
     pub fn by_id_mut(&mut self, id: Id) -> Option<&mut Box<Tabpage>> {
         self.all.iter_mut().find(|tab| tab.id == id)
+    }
+
+    pub fn has_edit_windows(&self) -> bool {
+        self.all.iter().any(|tab| tab.has_edit_windows())
     }
 
     pub fn windows_for_buffer(&mut self, buffer_id: Id) -> impl Iterator<Item = &mut Box<Window>> {

--- a/src/input/commands/connection.rs
+++ b/src/input/commands/connection.rs
@@ -81,21 +81,26 @@ fn connect(context: &mut CommandHandlerContext, url: String) -> KeyResult {
 }
 
 fn disconnect(context: &mut CommandHandlerContext) -> KeyResult {
-    let buffer_id = context.state().current_buffer().id();
-    context
-        .state_mut()
-        .connections
-        .as_mut()
-        .unwrap()
-        .disconnect_buffer(buffer_id)?;
+    if let Some(buffer_id) = context.state().current_buffer().connection_buffer_id() {
+        context
+            .state_mut()
+            .connections
+            .as_mut()
+            .unwrap()
+            .disconnect_buffer(buffer_id)?;
 
-    context
-        .state_mut()
-        .winsbuf_by_id(buffer_id)
-        .expect("Could not find current buffer")
-        .append_line("Disconnected.".into());
+        context
+            .state_mut()
+            .winsbuf_by_id(buffer_id)
+            .expect("Could not find current buffer")
+            .append_line("Disconnected.".into());
 
-    Ok(())
+        Ok(())
+    } else {
+        Err(KeyError::InvalidInput(
+            "No connection for current buffer".to_string(),
+        ))
+    }
 }
 
 #[cfg(test)]

--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -32,11 +32,19 @@ fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyRes
 
     if let Some(id) = connection_buffer_id {
         // make sure we disconnect if there are no more windows
-        if context
+        let is_connected = context
             .state_mut()
-            .tabpages
-            .containing_buffer_mut(id)
-            .is_none()
+            .connections
+            .as_mut()
+            .unwrap()
+            .by_buffer_id(id)
+            .is_some();
+        if is_connected
+            && context
+                .state_mut()
+                .tabpages
+                .containing_buffer_mut(id)
+                .is_none()
         {
             let name = buffer_connection_name(context, id);
             context

--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -90,4 +90,27 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn quit_connection_window_test() -> KeyResult {
+        let mut state = crate::app::State::default();
+        let buf_id = state.buffers.create().id();
+        let tab = state.tabpages.current_tab_mut();
+        tab.new_connection(&mut state.buffers, buf_id);
+
+        let mut context = TestKeymapContext {
+            state,
+            keys: MemoryKeySource::from_keys(""),
+        };
+        let mut ctx = CommandHandlerContext {
+            context: Box::new(&mut context),
+            input: "q".to_string(),
+        };
+
+        // NOTE: it should close both the input window and the output
+        quit_window(&mut ctx, HideBufArgs { force: false })?;
+        assert_eq!(ctx.context.state_mut().running, false);
+
+        Ok(())
+    }
 }

--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -69,25 +69,15 @@ fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyRes
 
 #[cfg(test)]
 mod tests {
-    use crate::{
-        editing::motion::tests::TestKeymapContext, input::source::memory::MemoryKeySource,
-    };
+    use crate::editing::motion::tests::TestKeymapContext;
 
     use super::*;
 
     #[test]
     fn quit_single_windows_test() -> KeyResult {
-        let mut state = crate::app::State::default();
-        state.current_tab_mut().vsplit();
-
-        let mut context = TestKeymapContext {
-            state,
-            keys: MemoryKeySource::from_keys(""),
-        };
-        let mut ctx = CommandHandlerContext {
-            context: Box::new(&mut context),
-            input: "q".to_string(),
-        };
+        let mut context = TestKeymapContext::empty();
+        let mut ctx = context.command_context("q");
+        ctx.state_mut().current_tab_mut().vsplit();
 
         quit_window(&mut ctx, HideBufArgs { force: false })?;
         assert_eq!(ctx.context.state_mut().running, true);
@@ -101,19 +91,13 @@ mod tests {
 
     #[test]
     fn quit_connection_window_test() -> KeyResult {
-        let mut state = crate::app::State::default();
+        let mut context = TestKeymapContext::empty();
+        let mut ctx = context.command_context("q");
+
+        let state = ctx.state_mut();
         let buf_id = state.buffers.create().id();
         let tab = state.tabpages.current_tab_mut();
         tab.new_connection(&mut state.buffers, buf_id);
-
-        let mut context = TestKeymapContext {
-            state,
-            keys: MemoryKeySource::from_keys(""),
-        };
-        let mut ctx = CommandHandlerContext {
-            context: Box::new(&mut context),
-            input: "q".to_string(),
-        };
 
         // NOTE: it should close both the input window and the output
         quit_window(&mut ctx, HideBufArgs { force: false })?;

--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -1,6 +1,11 @@
 use crate::{
     declare_commands,
-    input::{KeyError, KeymapContext},
+    input::{maps::KeyResult, KeyError, KeymapContext},
+};
+
+use super::{
+    helpers::{buffer_connection_name, check_hide_buffer, HideBufArgs},
+    CommandHandlerContext,
 };
 
 declare_commands!(declare_core {
@@ -14,7 +19,75 @@ declare_commands!(declare_core {
     },
 
     pub fn quit(context) {
-        context.state_mut().running = false;
-        Ok(())
+        quit_window(context, HideBufArgs { force: false })
     },
 });
+
+fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyResult {
+    check_hide_buffer(context, args)?;
+
+    let connection_buffer_id = context.state().current_buffer().connection_buffer_id();
+    let win_id = context.state().current_window().id;
+    context.state_mut().current_tab_mut().close_window(win_id);
+
+    if let Some(id) = connection_buffer_id {
+        // make sure we disconnect if there are no more windows
+        if context
+            .state_mut()
+            .tabpages
+            .containing_buffer_mut(id)
+            .is_none()
+        {
+            let name = buffer_connection_name(context, id);
+            context
+                .state_mut()
+                .echom(format!("{}: Disconnected.", name));
+
+            context
+                .state_mut()
+                .connections
+                .as_mut()
+                .unwrap()
+                .disconnect_buffer(id)?;
+        }
+    }
+
+    if !context.state().tabpages.has_edit_windows() {
+        context.state_mut().running = false;
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        editing::motion::tests::TestKeymapContext, input::source::memory::MemoryKeySource,
+    };
+
+    use super::*;
+
+    #[test]
+    fn quit_single_windows_test() -> KeyResult {
+        let mut state = crate::app::State::default();
+        state.current_tab_mut().vsplit();
+
+        let mut context = TestKeymapContext {
+            state,
+            keys: MemoryKeySource::from_keys(""),
+        };
+        let mut ctx = CommandHandlerContext {
+            context: Box::new(&mut context),
+            input: "q".to_string(),
+        };
+
+        quit_window(&mut ctx, HideBufArgs { force: false })?;
+        assert_eq!(ctx.context.state_mut().running, true);
+        assert_eq!(ctx.context.state_mut().current_window().focused, true);
+
+        quit_window(&mut ctx, HideBufArgs { force: false })?;
+        assert_eq!(ctx.context.state_mut().running, false);
+
+        Ok(())
+    }
+}

--- a/src/input/commands/helpers.rs
+++ b/src/input/commands/helpers.rs
@@ -1,0 +1,64 @@
+/*!
+ * Shared helper logic
+ */
+
+use crate::{
+    editing::{source::BufferSource, Id},
+    input::{maps::KeyResult, KeyError, KeymapContext},
+};
+
+use super::CommandHandlerContext;
+
+pub struct HideBufArgs {
+    pub force: bool,
+}
+
+pub fn buffer_connection_name(context: &CommandHandlerContext, id: Id) -> String {
+    if let Some(buf) = context.state().buffers.by_id(id) {
+        if let BufferSource::Connection(uri) = buf.source() {
+            // it should
+            uri.clone()
+        } else {
+            format!("{:?}", buf.source())
+        }
+    } else {
+        let conn_id = context
+            .state()
+            .connections
+            .as_ref()
+            .unwrap()
+            .buffer_to_id(id)
+            .unwrap_or(id);
+        format!("Connection#{}", conn_id)
+    }
+}
+
+pub fn check_hide_buffer(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyResult {
+    if !args.force {
+        return Ok(());
+    }
+
+    if context.state().current_buffer().is_modified() {
+        // TODO actually, if the buffer is saved or open in another window,
+        // we should be allowed to hide it.
+        return Err(KeyError::NotPermitted(
+            "No write since last change".to_string(),
+        ));
+    }
+
+    if let Some(id) = context.state().current_buffer().connection_buffer_id() {
+        if context
+            .state_mut()
+            .connections
+            .as_mut()
+            .unwrap()
+            .by_buffer_id(id)
+            .is_some()
+        {
+            let name = buffer_connection_name(context, id);
+            return Err(KeyError::NotPermitted(format!("{}: Still connected", name)));
+        }
+    }
+
+    Ok(())
+}

--- a/src/input/commands/helpers.rs
+++ b/src/input/commands/helpers.rs
@@ -34,7 +34,7 @@ pub fn buffer_connection_name(context: &CommandHandlerContext, id: Id) -> String
 }
 
 pub fn check_hide_buffer(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyResult {
-    if !args.force {
+    if args.force {
         return Ok(());
     }
 

--- a/src/input/commands/mod.rs
+++ b/src/input/commands/mod.rs
@@ -6,6 +6,8 @@ pub mod log;
 pub mod registry;
 pub mod window;
 
+mod helpers;
+
 use std::time::Duration;
 
 use crate::delegate_keysource;


### PR DESCRIPTION
Ensures that, when the last window of a connection is closed, so is its connection. We could theoretically support a "hidden" flag that would keep the connection around (its buffer still is!) but I don't think we need to support that right away.

This as the default behavior seems intuitive.

- Update :quit to actually close windows properly
- Add connection layout closing test
- Fix flipped boolean check
- Handle disconnection more gracefully
