### PR TITLE
Allow closing secondary splits of a window

### DIFF
--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -145,6 +145,11 @@ impl Connections {
         self.buffer_to_connection.insert(buffer_id, connection.id());
         self.all.push(connection);
     }
+
+    #[cfg(test)]
+    pub fn add_for_test(&mut self, buffer_id: Id, connection: Box<dyn Connection>) {
+        self.add(buffer_id, connection);
+    }
 }
 
 #[derive(PartialEq)]

--- a/src/editing/window.rs
+++ b/src/editing/window.rs
@@ -1,3 +1,5 @@
+use bitflags::bitflags;
+
 use std::cmp::{max, min};
 
 use crate::{
@@ -7,12 +9,25 @@ use crate::{
 
 use super::{buffers::Buffers, Buffer, CursorPosition, HasId, Id, Resizable, Size};
 
+bitflags! {
+    pub struct WindowFlags: u8 {
+        const NONE = 0;
+
+        /// A PROTECTED window is not normally closeable, but the contextually
+        /// it may be closed depending on its content. For example, the
+        /// "main" window of a Connection is PROTECTED but may be closed
+        /// if the connection is not active
+        const PROTECTED = 0b01;
+    }
+}
+
 pub struct Window {
     pub id: Id,
     pub buffer: Id,
     pub size: Size,
     pub focused: bool,
     pub inserting: bool,
+    pub flags: WindowFlags,
 
     pub cursor: CursorPosition,
 
@@ -35,6 +50,7 @@ impl Window {
             buffer: buffer_id,
             size: Size { w: 0, h: 0 },
             focused,
+            flags: WindowFlags::NONE,
             inserting: false,
             cursor: CursorPosition { line: 0, col: 0 },
             scrolled_lines: 0,

--- a/src/input/commands/helpers.rs
+++ b/src/input/commands/helpers.rs
@@ -3,6 +3,7 @@
  */
 
 use crate::{
+    editing::window::WindowFlags,
     editing::{source::BufferSource, Id},
     input::{maps::KeyResult, KeyError, KeymapContext},
 };
@@ -38,27 +39,135 @@ pub fn check_hide_buffer(context: &mut CommandHandlerContext, args: HideBufArgs)
         return Ok(());
     }
 
-    if context.state().current_buffer().is_modified() {
-        // TODO actually, if the buffer is saved or open in another window,
-        // we should be allowed to hide it.
+    let connection_buffer_id = context.state().current_buffer().connection_buffer_id();
+    let buf_id_to_protect = if let Some(id) = connection_buffer_id {
+        id
+    } else {
+        context.state().current_buffer().id()
+    };
+    let has_other_window = context
+        .state_mut()
+        .tabpages
+        .windows_for_buffer(buf_id_to_protect)
+        .count()
+        > 1;
+
+    if context.state().current_buffer().is_modified() && !has_other_window {
         return Err(KeyError::NotPermitted(
             "No write since last change".to_string(),
         ));
     }
 
-    if let Some(id) = context.state().current_buffer().connection_buffer_id() {
-        if context
+    if let Some(id) = connection_buffer_id {
+        let is_connected = context
             .state_mut()
             .connections
             .as_mut()
             .unwrap()
             .by_buffer_id(id)
-            .is_some()
+            .is_some();
+
+        // disallow closing the main window
+        let name = buffer_connection_name(context, id);
+        if is_connected
+            && has_other_window
+            && context
+                .state()
+                .current_window()
+                .flags
+                .contains(WindowFlags::PROTECTED)
         {
-            let name = buffer_connection_name(context, id);
+            return Err(KeyError::NotPermitted(format!(
+                "{}: You may not close the primary connection windows",
+                name
+            )));
+        } else if is_connected && !has_other_window {
             return Err(KeyError::NotPermitted(format!("{}: Still connected", name)));
         }
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(test)]
+    mod check_hide_buffer {
+        use crate::editing::FocusDirection;
+        use crate::{connection::Connection, editing::motion::tests::TestKeymapContext};
+
+        use super::*;
+
+        struct TestConnection;
+
+        impl Connection for TestConnection {
+            fn id(&self) -> Id {
+                0
+            }
+
+            fn read(&mut self) -> std::io::Result<Option<crate::connection::ReadValue>> {
+                Ok(None)
+            }
+
+            fn write(&mut self, _bytes: &[u8]) -> std::io::Result<()> {
+                Ok(())
+            }
+        }
+
+        #[test]
+        fn disallow_hiding_connlayout() -> KeyResult {
+            let mut context = TestKeymapContext::empty();
+            let mut ctx = context.command_context("q");
+
+            let state = ctx.state_mut();
+            let buffer = state.buffers.create_mut();
+            buffer.set_source(BufferSource::Connection("serenity.co".to_string()));
+            let buf_id = buffer.id();
+            let tab = state.tabpages.current_tab_mut();
+            let conn_layout = tab.new_connection(&mut state.buffers, buf_id);
+            tab.replace_window(tab.current_window().id, Box::new(conn_layout));
+
+            state
+                .connections
+                .as_mut()
+                .unwrap()
+                .add_for_test(buf_id, Box::new(TestConnection));
+
+            // we should not be able to hide a single, connected window
+            let connected = check_hide_buffer(&mut ctx, HideBufArgs { force: false });
+            match connected {
+                Ok(_) => panic!("Should not allow connected window hide!"),
+                Err(e) => {
+                    assert!(format!("{:?}", e).contains("Still connected"));
+                }
+            }
+
+            // a split window should be hideable
+            let split_id = ctx.state_mut().current_tab_mut().vsplit();
+            ctx.state_mut().current_tab_mut().set_focus(split_id);
+            match check_hide_buffer(&mut ctx, HideBufArgs { force: false }) {
+                Ok(_) => {}
+                Err(e) => panic!(e),
+            }
+
+            // the original connlayout should NOT be hideable
+            let tab = ctx.state_mut().current_tab_mut();
+            tab.move_focus(FocusDirection::Left);
+            tab.move_focus(FocusDirection::Up);
+
+            assert_eq!(ctx.state().current_buffer().id(), buf_id);
+
+            let layout_result = check_hide_buffer(&mut ctx, HideBufArgs { force: false });
+            match layout_result {
+                Ok(_) => panic!("Should not allow main window hide!"),
+                Err(e) => {
+                    assert!(format!("{:?}", e).contains("primary"));
+                }
+            }
+
+            Ok(())
+        }
+    }
 }


### PR DESCRIPTION
Connection windows are special cased while connected so the input window
isn't lost. A more robust solution might try to attach a new input
window upon entering a lone connection output window (for example, if
you hide the output window while still connected, if we ever do that...)
