### PR TITLE
Support completion for command args

### DIFF
--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -111,6 +111,11 @@ impl Buffer for UndoableBuffer {
     }
 
     fn insert_lines(&mut self, line_index: usize, text: TextLines) {
+        if text.lines.is_empty() {
+            // nop
+            return;
+        }
+
         let start = CursorPosition {
             line: line_index,
             col: 0,

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -184,8 +184,11 @@ pub mod tests {
             Buffer, HasId, Resizable, Size,
         },
         input::{
-            commands::{registry::CommandRegistry, CommandHandlerContext},
-            completion::CompletableContext,
+            commands::{
+                registry::{CommandRegistry, CommandSpec},
+                CommandHandlerContext,
+            },
+            completion::{tests::StaticCompleter, CompletableContext},
             source::memory::MemoryKeySource,
             KeySource, Keymap, KeymapContext,
         },
@@ -248,6 +251,21 @@ pub mod tests {
 
         pub fn set_inserting(&mut self, inserting: bool) {
             self.window.set_inserting(inserting);
+        }
+
+        pub fn mock_command_completions(
+            &mut self,
+            command_name: &'static str,
+            completions: Vec<&'static str>,
+        ) {
+            let completion_strings = completions.iter().map(|s| s.to_string()).collect();
+            self.commands.insert(
+                command_name.to_string(),
+                CommandSpec {
+                    handler: Box::new(|_ctx| Ok(())),
+                    completer: Some(Box::new(StaticCompleter::new(completion_strings))),
+                },
+            );
         }
 
         pub fn feed_keys<K: Keymap>(mut self, mut keymap: K, keys: &str) -> Self {

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -259,13 +259,9 @@ pub mod tests {
             completions: Vec<&'static str>,
         ) {
             let completion_strings = completions.iter().map(|s| s.to_string()).collect();
-            self.commands.insert(
-                command_name.to_string(),
-                CommandSpec {
-                    handler: Box::new(|_ctx| Ok(())),
-                    completer: Some(Box::new(StaticCompleter::new(completion_strings))),
-                },
-            );
+            let mut spec = CommandSpec::handler(Box::new(|_ctx| Ok(())));
+            spec.push_arg_completer(Box::new(StaticCompleter::new(completion_strings)));
+            self.commands.insert(command_name.to_string(), spec);
         }
 
         pub fn feed_keys<K: Keymap>(mut self, mut keymap: K, keys: &str) -> Self {

--- a/src/input/commands/file.rs
+++ b/src/input/commands/file.rs
@@ -9,7 +9,7 @@ use crate::{
     },
     input::{maps::KeyResult, KeyError},
 };
-use std::fs;
+use std::{fs, path::PathBuf};
 
 use crate::{declare_commands, input::KeymapContext};
 
@@ -51,7 +51,7 @@ declare_commands!(declare_file {
         Ok(())
     },
 
-    pub fn write(context, given_path: Optional<String>) {
+    pub fn write(context, given_path: Optional<PathBuf>) {
         let current_path = match context.state().current_buffer().source() {
             &BufferSource::LocalFile(ref path) => Some(path.clone()),
             _ => None,
@@ -60,7 +60,7 @@ declare_commands!(declare_file {
         let path = if let Some(path) = given_path {
             path
         } else if let Some(path) = current_path {
-            path.clone()
+            PathBuf::from(path.clone())
         } else {
             return Err(KeyError::InvalidInput("No file name".to_string()));
         };
@@ -69,7 +69,7 @@ declare_commands!(declare_file {
     },
 });
 
-fn write(context: &mut CommandHandlerContext, path: String) -> KeyResult {
+fn write(context: &mut CommandHandlerContext, path: PathBuf) -> KeyResult {
     let content = context.state().current_buffer().get_contents();
     let lines_count = context.state().current_buffer().lines_count();
     let bytes = content.as_bytes().len();
@@ -78,7 +78,9 @@ fn write(context: &mut CommandHandlerContext, path: String) -> KeyResult {
 
     context.state_mut().echom(format!(
         "\"{}\": {}L, {}B written",
-        path, lines_count, bytes,
+        path.to_string_lossy(),
+        lines_count,
+        bytes,
     ));
 
     // if we don't already have a source, set it

--- a/src/input/commands/file.rs
+++ b/src/input/commands/file.rs
@@ -17,18 +17,26 @@ use super::helpers::{check_hide_buffer, HideBufArgs};
 use super::CommandHandlerContext;
 
 declare_commands!(declare_file {
-    pub fn edit(context, file_path: String) {
+    pub fn edit(context, file_path: PathBuf) {
         check_hide_buffer(context, HideBufArgs { force: false })?;
 
-        // TODO if the file doesn't exist, we should still be able to edit it
-        let full_path = fs::canonicalize(&file_path)?;
-        let contents = fs::read_to_string(&full_path)?;
-        let bytes = contents.as_bytes().len();
-        let lines: Vec<TextLine> = contents.split("\n").map(|line| line.to_owned().into()).collect();
-        let lines_count = lines.len();
+        let (full_path_string, lines) = if file_path.exists() {
+            let contents = fs::read_to_string(&file_path)?;
+            let bytes = contents.as_bytes().len();
+            let lines: Vec<TextLine> = contents.split("\n").map(|line| line.to_owned().into()).collect();
+            let lines_count = lines.len();
 
-        let full_path_string = full_path.to_string_lossy();
-        context.state_mut().echom(format!("\"{}\": {}L, {}B", full_path_string, lines_count, bytes));
+            let canonical = file_path.canonicalize().unwrap();
+            let full_path_string = canonical.to_string_lossy().to_string();
+            context.state_mut().echom(format!("\"{}\": {}L, {}B", full_path_string, lines_count, bytes));
+
+            (full_path_string, lines)
+        } else {
+            let full_path_string = file_path.to_string_lossy().to_string();
+            context.state_mut().echom(format!("\"{}\": [New]", full_path_string));
+
+            (full_path_string, vec![])
+        };
 
         let buffer_id = {
             let buf = context.state_mut().buffers.create_mut();

--- a/src/input/commands/registry.rs
+++ b/src/input/commands/registry.rs
@@ -52,6 +52,20 @@ impl CommandRegistry {
         self.commands.insert(name, spec);
     }
 
+    pub fn get(&self, name: &String) -> Option<&CommandSpec> {
+        if let Some(handler) = self.commands.get(name) {
+            return Some(handler);
+        }
+
+        if let Some(full_name) = self.abbreviations.get(name) {
+            if let Some(handler) = self.commands.get(full_name) {
+                return Some(handler);
+            }
+        }
+
+        None
+    }
+
     pub fn take(&mut self, name: &String) -> Option<(String, CommandSpec)> {
         if let Some(handler) = self.commands.remove(name) {
             return Some((name.clone(), handler));

--- a/src/input/commands/registry.rs
+++ b/src/input/commands/registry.rs
@@ -102,7 +102,12 @@ macro_rules! command_arg_completer {
         );
     };
 
-    ($r:ident@$name:ident -> $unsupported:ty) => {};
+    ($r:ident@$name:ident -> $unsupported:ty) => {
+        $r.declare_arg(
+            stringify!($name).to_string(),
+            Box::new(crate::input::completion::empty::EmptyCompleter),
+        );
+    };
 }
 
 #[macro_export]

--- a/src/input/commands/registry.rs
+++ b/src/input/commands/registry.rs
@@ -89,6 +89,14 @@ macro_rules! command_arg {
     // NOTE: all arg types are parsed as optional; there is a single
     // rule at the end that handles required args
 
+    ($name:ident@$args:ident -> $arg:ident: Optional<PathBuf>) => {
+        let $arg = if let Some(raw) = $args.next() {
+            Some(std::path::PathBuf::from(raw))
+        } else {
+            None
+        };
+    };
+
     ($name:ident@$args:ident -> $arg:ident: Optional<String>) => {
         let $arg = if let Some(raw) = $args.next() {
             Some(raw.to_string())

--- a/src/input/commands/registry.rs
+++ b/src/input/commands/registry.rs
@@ -95,18 +95,28 @@ impl CommandRegistry {
 
 #[macro_export]
 macro_rules! command_arg_completer {
-    ($r:ident@$name:ident -> PathBuf) => {
+    ($r:ident@$name:ident => $completer:expr) => {
         $r.declare_arg(
             stringify!($name).to_string(),
-            Box::new(crate::input::completion::file::FileCompleter),
+            Box::new($completer),
         );
     };
 
-    ($r:ident@$name:ident -> $unsupported:ty) => {
-        $r.declare_arg(
-            stringify!($name).to_string(),
-            Box::new(crate::input::completion::empty::EmptyCompleter),
+    ($r:ident@$name:ident -> PathBuf) => {
+        crate::command_arg_completer!(
+            $r@$name =>
+            crate::input::completion::file::FileCompleter
         );
+    };
+
+    // unwrap optional types to their base type
+    ($r:ident@$name:ident -> Optional<$type:ident>) => {
+        crate::command_arg_completer!($r@$name -> $type);
+    };
+
+    // catchall placeholder:
+    ($r:ident@$name:ident -> $unsupported:ty) => {
+        crate::command_arg_completer!($r@$name => crate::input::completion::empty::EmptyCompleter);
     };
 }
 

--- a/src/input/commands/registry.rs
+++ b/src/input/commands/registry.rs
@@ -4,12 +4,9 @@ use crate::input::completion::Completer;
 
 use super::CommandHandler;
 
-pub type CommandCompleter =
-    dyn Completer<Iter = Box<dyn Iterator<Item = crate::input::completion::Completion>>>;
-
 pub struct CommandSpec {
     pub handler: Box<CommandHandler>,
-    pub completer: Option<Box<CommandCompleter>>,
+    pub completer: Option<Box<dyn Completer>>,
 }
 
 impl CommandSpec {

--- a/src/input/commands/registry.rs
+++ b/src/input/commands/registry.rs
@@ -3,6 +3,7 @@ use std::collections::{hash_map, HashMap};
 use crate::input::completion::Completer;
 
 use super::CommandHandler;
+use crate::input::completion::file::FileCompleter;
 
 pub struct CommandSpec {
     pub handler: Box<CommandHandler>,
@@ -13,7 +14,9 @@ impl CommandSpec {
     pub fn handler(handler: Box<CommandHandler>) -> Self {
         Self {
             handler,
-            completer: None,
+            // completer: None,
+            // FIXME STOPSHIP: this should be specified by the command, not forced
+            completer: Some(Box::new(FileCompleter)),
         }
     }
 }

--- a/src/input/completion/args.rs
+++ b/src/input/completion/args.rs
@@ -1,0 +1,34 @@
+use super::Completer;
+use crate::input::completion::empty::EmptyCompleter;
+
+pub struct CommandArgsCompleter {
+    delegates: Vec<Box<dyn Completer>>,
+}
+
+impl CommandArgsCompleter {
+    pub fn new() -> Self {
+        Self {
+            delegates: Vec::new(),
+        }
+    }
+
+    pub fn push(&mut self, delegate: Box<dyn Completer>) {
+        self.delegates.push(delegate);
+    }
+}
+
+impl Completer for CommandArgsCompleter {
+    fn suggest(
+        &self,
+        app: Box<&dyn super::CompletableContext>,
+        context: super::CompletionContext,
+    ) -> super::BoxedSuggestions {
+        // NOTE: word #0 would be the command
+        let index = context.word_index().checked_sub(1).unwrap_or(0);
+        if let Some(delegate) = self.delegates.get(index) {
+            delegate.suggest(app, context)
+        } else {
+            EmptyCompleter.suggest(app, context)
+        }
+    }
+}

--- a/src/input/completion/commands.rs
+++ b/src/input/completion/commands.rs
@@ -36,9 +36,7 @@ impl Completer for CommandsCompleter {
 
         let command = context.nth_word(0).unwrap().to_string();
         if let Some(spec) = app.commands().get(&command) {
-            if let Some(completer) = spec.completer.as_ref() {
-                return completer.suggest(app, context);
-            }
+            return spec.completer.suggest(app, context);
         }
 
         // fallback if no completions are available

--- a/src/input/completion/commands.rs
+++ b/src/input/completion/commands.rs
@@ -34,8 +34,7 @@ impl Completer for CommandsCompleter {
             return CommandNamesCompleter.suggest(app, context);
         }
 
-        // NOTE: this 1 skips the `:`
-        let command = context.nth_word(0).unwrap()[1..].to_string();
+        let command = context.nth_word(0).unwrap().to_string();
         if let Some(spec) = app.commands().get(&command) {
             if let Some(completer) = spec.completer.as_ref() {
                 return completer.suggest(app, context);
@@ -44,5 +43,30 @@ impl Completer for CommandsCompleter {
 
         // fallback if no completions are available
         EmptyCompleter.suggest(app, context)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{editing::motion::tests::window, input::completion::tests::complete};
+
+    use super::*;
+
+    #[test]
+    fn delegates_to_command_for_arg() {
+        let mut app = window(":e s|");
+        app.mock_command_completions("e", vec!["serenity"]);
+
+        let suggestions = complete(&CommandsCompleter, &mut app);
+        assert_eq!(suggestions, vec!["serenity".to_string()]);
+    }
+
+    #[test]
+    fn delegates_to_command_for_empty_arg() {
+        let mut app = window(":e |");
+        app.mock_command_completions("e", vec!["serenity"]);
+
+        let suggestions = complete(&CommandsCompleter, &mut app);
+        assert_eq!(suggestions, vec!["serenity".to_string()]);
     }
 }

--- a/src/input/completion/commands.rs
+++ b/src/input/completion/commands.rs
@@ -1,8 +1,11 @@
 use crate::declare_simple_completer;
 use genawaiter::{sync::gen, yield_};
 
+use super::empty::EmptyCompleter;
+use super::Completer;
+
 declare_simple_completer!(
-    CommandsCompleter (app, context) {
+    CommandNamesCompleter (app, context) {
         let names: Vec<String> = app.commands()
             .names()
             .map(|v| v.to_string())
@@ -17,3 +20,29 @@ declare_simple_completer!(
         })
     }
 );
+
+pub struct CommandsCompleter;
+
+impl Completer for CommandsCompleter {
+    fn suggest(
+        &self,
+        app: Box<&dyn super::CompletableContext>,
+        context: super::CompletionContext,
+    ) -> super::BoxedSuggestions {
+        let (start, _) = context.word_range();
+        if start <= 1 {
+            return CommandNamesCompleter.suggest(app, context);
+        }
+
+        // NOTE: this 1 skips the `:`
+        let command = context.nth_word(0).unwrap()[1..].to_string();
+        if let Some(spec) = app.commands().get(&command) {
+            if let Some(completer) = spec.completer.as_ref() {
+                return completer.suggest(app, context);
+            }
+        }
+
+        // fallback if no completions are available
+        EmptyCompleter.suggest(app, context)
+    }
+}

--- a/src/input/completion/empty.rs
+++ b/src/input/completion/empty.rs
@@ -1,0 +1,9 @@
+use genawaiter::sync::gen;
+
+use crate::declare_simple_completer;
+
+declare_simple_completer!(
+    EmptyCompleter (_app, _context) {
+        gen!({})
+    }
+);

--- a/src/input/completion/file.rs
+++ b/src/input/completion/file.rs
@@ -1,0 +1,55 @@
+use genawaiter::{sync::gen, yield_};
+use std::path::PathBuf;
+
+use crate::declare_simple_completer;
+
+declare_simple_completer!(
+    FileCompleter (_app, context) {
+        let given_path = PathBuf::from(context.word());
+        gen!({
+            let mut path = if let Ok(path) = std::env::current_dir() {
+                path
+            } else {
+                return;
+            };
+
+            path.push(given_path);
+
+            if let Ok(dir) = path.read_dir() {
+                for child in dir {
+                    if let Ok(entry) = child {
+                        yield_!(entry.file_name().to_string_lossy().to_string());
+                    }
+                }
+            }
+
+            if let Some(parent) = path.parent() {
+                if let Ok(parent_dir) = parent.read_dir() {
+                    for sibling in parent_dir {
+                        if let Ok(entry) = sibling {
+                            yield_!(entry.file_name().to_string_lossy().to_string());
+                        }
+                    }
+                }
+            }
+        })
+    }
+);
+
+#[cfg(test)]
+mod tests {
+    use crate::{editing::motion::tests::window, input::completion::tests::complete};
+
+    use super::*;
+
+    #[test]
+    fn complete_files() {
+        let mut app = window(":e C|");
+
+        let suggestions = complete(&FileCompleter, &mut app);
+        assert_eq!(
+            suggestions,
+            vec!["Cargo.toml".to_string(), "Cargo.lock".to_string()]
+        );
+    }
+}

--- a/src/input/completion/impl_macro.rs
+++ b/src/input/completion/impl_macro.rs
@@ -2,13 +2,11 @@
 macro_rules! impl_simple_completer {
     ($completer_name:ident ($app:ident, $context:ident) $body:expr) => {
         impl crate::input::completion::Completer for $completer_name {
-            type Iter = Box<dyn Iterator<Item = crate::input::completion::Completion>>;
-
             fn suggest(
                 &self,
                 $app: Box<&dyn crate::input::completion::CompletableContext>,
                 $context: crate::input::completion::CompletionContext,
-            ) -> Self::Iter {
+            ) -> crate::input::completion::BoxedSuggestions {
                 let _input = $context.word().to_string();
                 Box::new(
                     $body

--- a/src/input/completion/impl_macro.rs
+++ b/src/input/completion/impl_macro.rs
@@ -1,9 +1,9 @@
 #[macro_export]
 macro_rules! impl_simple_completer {
-    ($completer_name:ident ($app:ident, $context:ident) $body:expr) => {
+    ($completer_name:ident (&$self:ident, $app:ident, $context:ident) $body:expr) => {
         impl crate::input::completion::Completer for $completer_name {
             fn suggest(
-                &self,
+                &$self,
                 $app: Box<&dyn crate::input::completion::CompletableContext>,
                 $context: crate::input::completion::CompletionContext,
             ) -> crate::input::completion::BoxedSuggestions {
@@ -18,9 +18,13 @@ macro_rules! impl_simple_completer {
         }
     };
 
+    ($completer_name:ident ($app:ident, $context:ident) $body:expr) => {
+        crate::impl_simple_completer!($completer_name (&self, $app, $context) $body);
+    };
+
     ($completer_name:ident $body:expr) => {
-        crate::impl_simple_completer!($completer_name (_app, _context) $body);
-    }
+        crate::impl_simple_completer!($completer_name (&self, _app, _context) $body);
+    };
 }
 
 #[macro_export]

--- a/src/input/completion/impl_macro.rs
+++ b/src/input/completion/impl_macro.rs
@@ -4,9 +4,9 @@ macro_rules! impl_simple_completer {
         impl crate::input::completion::Completer for $completer_name {
             type Iter = Box<dyn Iterator<Item = crate::input::completion::Completion>>;
 
-            fn suggest<T: crate::input::completion::CompletableContext>(
+            fn suggest(
                 &self,
-                $app: &T,
+                $app: Box<&dyn crate::input::completion::CompletableContext>,
                 $context: crate::input::completion::CompletionContext,
             ) -> Self::Iter {
                 let _input = $context.word().to_string();

--- a/src/input/completion/mod.rs
+++ b/src/input/completion/mod.rs
@@ -99,7 +99,7 @@ impl Completion {
 pub trait Completer {
     type Iter: Iterator<Item = Completion>;
 
-    fn suggest<T: CompletableContext>(&self, app: &T, context: CompletionContext) -> Self::Iter;
+    fn suggest(&self, app: Box<&dyn CompletableContext>, context: CompletionContext) -> Self::Iter;
 }
 
 #[cfg(test)]

--- a/src/input/completion/mod.rs
+++ b/src/input/completion/mod.rs
@@ -24,14 +24,23 @@ pub struct CompletionContext {
 }
 
 impl CompletionContext {
-    pub fn word_range(&self) -> (usize, usize) {
+    pub fn word_range_where(&self, is_word: impl Fn(char) -> bool) -> (usize, usize) {
         for i in (0..self.cursor).rev() {
-            let is_end_of_word = self.text[i..i + 1].find(|c| !self.is_keyword(c));
+            let is_end_of_word = self.text[i..i + 1].find(|c| !is_word(c));
             if is_end_of_word.is_some() {
                 return (i + 1, self.cursor);
             }
         }
         return (0, self.cursor);
+    }
+
+    pub fn word_range(&self) -> (usize, usize) {
+        self.word_range_where(|c| self.is_keyword(c))
+    }
+
+    pub fn word_where(&self, is_word: impl Fn(char) -> bool) -> &str {
+        let (start, end) = self.word_range_where(is_word);
+        return &self.text[start..end];
     }
 
     pub fn word(&self) -> &str {

--- a/src/input/completion/mod.rs
+++ b/src/input/completion/mod.rs
@@ -1,4 +1,5 @@
 pub mod commands;
+mod empty;
 mod impl_macro;
 pub mod state;
 
@@ -35,6 +36,10 @@ impl CompletionContext {
     pub fn word(&self) -> &str {
         let (start, end) = self.word_range();
         return &self.text[start..end];
+    }
+
+    pub fn nth_word(&self, n: usize) -> Option<&str> {
+        self.text.splitn(n + 1, " ").nth(n)
     }
 
     pub fn create_completion(&self, replacement: String) -> Completion {

--- a/src/input/completion/mod.rs
+++ b/src/input/completion/mod.rs
@@ -96,10 +96,14 @@ impl Completion {
     }
 }
 
-pub trait Completer {
-    type Iter: Iterator<Item = Completion>;
+pub type BoxedSuggestions = Box<dyn Iterator<Item = Completion>>;
 
-    fn suggest(&self, app: Box<&dyn CompletableContext>, context: CompletionContext) -> Self::Iter;
+pub trait Completer {
+    fn suggest(
+        &self,
+        app: Box<&dyn CompletableContext>,
+        context: CompletionContext,
+    ) -> BoxedSuggestions;
 }
 
 #[cfg(test)]

--- a/src/input/completion/mod.rs
+++ b/src/input/completion/mod.rs
@@ -1,3 +1,4 @@
+pub mod args;
 pub mod commands;
 mod empty;
 pub mod file;
@@ -46,6 +47,14 @@ impl CompletionContext {
     pub fn word(&self) -> &str {
         let (start, end) = self.word_range();
         return &self.text[start..end];
+    }
+
+    pub fn word_index(&self) -> usize {
+        self.text[0..self.cursor]
+            .split(" ")
+            .count()
+            .checked_sub(1) // if there's 1 word, index == 0
+            .unwrap_or(0)
     }
 
     pub fn nth_word(&self, n: usize) -> Option<&str> {

--- a/src/input/completion/mod.rs
+++ b/src/input/completion/mod.rs
@@ -1,6 +1,6 @@
 pub mod args;
 pub mod commands;
-mod empty;
+pub mod empty;
 pub mod file;
 mod impl_macro;
 pub mod state;

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -1,6 +1,28 @@
+use std::rc::Rc;
+
 use crate::{editing::motion::MotionContext, input::KeymapContext};
 
 use super::{CompletableContext, Completer, Completion, CompletionContext};
+
+pub struct BoxedCompleter {
+    delegate: Rc<dyn Completer>,
+}
+
+impl From<Rc<dyn Completer>> for BoxedCompleter {
+    fn from(delegate: Rc<dyn Completer>) -> Self {
+        BoxedCompleter { delegate }
+    }
+}
+
+impl Completer for BoxedCompleter {
+    fn suggest(
+        &self,
+        app: Box<&dyn CompletableContext>,
+        context: CompletionContext,
+    ) -> super::BoxedSuggestions {
+        self.delegate.suggest(app, context)
+    }
+}
 
 pub struct CompletionState {
     completions: Option<Box<dyn Iterator<Item = Completion>>>,
@@ -9,12 +31,12 @@ pub struct CompletionState {
 }
 
 impl CompletionState {
-    pub fn new<C: 'static + Completer, CTX: KeymapContext>(completer: C, ctx: &mut CTX) -> Self {
+    pub fn new<C: Completer, CTX: KeymapContext>(completer: C, ctx: &mut CTX) -> Self {
         let context: CompletionContext = ctx.state_mut().into();
         return Self::from_context(completer, ctx.state(), context);
     }
 
-    pub fn from_context<C: 'static + Completer, CTX: CompletableContext>(
+    pub fn from_context<C: Completer, CTX: CompletableContext>(
         completer: C,
         app: &CTX,
         context: CompletionContext,

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -22,7 +22,7 @@ impl CompletionState {
         let original = context.word();
         return Self::from_completions(
             context.create_completion(original.to_string()),
-            Box::new(completer.suggest(app, context)),
+            Box::new(completer.suggest(Box::new(app), context)),
         );
     }
 

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -5,7 +5,6 @@ use crate::{
         word::{is_small_word_boundary, WordMotion},
         Motion,
     },
-    input::completion::commands::CommandsCompleter,
     input::maps::actions::connection::send_current_input_buffer,
 };
 use crate::{
@@ -32,10 +31,11 @@ pub fn vim_insert_mappings() -> KeyTreeNode {
         "<tab>" => |ctx| {
             let mut state = if let Some(current_state) = ctx.state_mut().current_window_mut().completion_state.take() {
                 current_state
+            } else if let Some(completer) = ctx.keymap.completer() {
+                CompletionState::new(completer, &mut ctx)
             } else {
-                // TODO get the completer to use from context/window/buffer, probably
-                let c = CommandsCompleter;
-                CompletionState::new(c, &mut ctx)
+                // no completer!
+                return Ok(());
             };
 
             state.apply_next(ctx.state_mut());

--- a/src/input/maps/vim/mode_stack.rs
+++ b/src/input/maps/vim/mode_stack.rs
@@ -23,14 +23,6 @@ impl VimModeStack {
         self.stack.contains(mode_id)
     }
 
-    pub fn peek(&self) -> Option<&VimMode> {
-        if let Some(name) = self.stack.last() {
-            self.modes.get(name)
-        } else {
-            None
-        }
-    }
-
     pub fn push(&mut self, new_mode: VimMode) {
         self.stack.push(new_mode.id.clone());
         self.modes.insert(new_mode.id.clone(), new_mode);

--- a/src/input/maps/vim/mode_stack.rs
+++ b/src/input/maps/vim/mode_stack.rs
@@ -23,6 +23,14 @@ impl VimModeStack {
         self.stack.contains(mode_id)
     }
 
+    pub fn peek(&self) -> Option<&VimMode> {
+        if let Some(name) = self.stack.last() {
+            self.modes.get(name)
+        } else {
+            None
+        }
+    }
+
     pub fn push(&mut self, new_mode: VimMode) {
         self.stack.push(new_mode.id.clone());
         self.modes.insert(new_mode.id.clone(), new_mode);

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -18,12 +18,9 @@ use super::{
 
 fn handle_command(mut context: &mut CommandHandlerContext) -> KeyResult {
     if let Some(command) = context.command().and_then(|s| Some(s.to_string())) {
-        if let Some((name, handler)) = context.state_mut().builtin_commands.take(&command) {
-            let result = handler(&mut context);
-            context
-                .state_mut()
-                .builtin_commands
-                .declare(name, false, handler);
+        if let Some((name, spec)) = context.state_mut().builtin_commands.take(&command) {
+            let result = (spec.handler)(&mut context);
+            context.state_mut().builtin_commands.insert(name, spec);
             result
         } else {
             Err(KeyError::NoSuchCommand(command))

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,6 +1,11 @@
 mod window;
 
-use crate::input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext};
+use std::rc::Rc;
+
+use crate::input::{
+    commands::CommandHandlerContext, completion::commands::CommandsCompleter, maps::KeyResult,
+    KeyError, KeymapContext,
+};
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
@@ -40,7 +45,7 @@ fn cmd_mode_access() -> KeyTreeNode {
             ctx.keymap.push_mode(VimPromptConfig{
                 prompt: ":".into(),
                 handler: Box::new(handle_command),
-                // TODO autocomplete
+                completer: Some(Rc::new(CommandsCompleter)),
             }.into());
             Ok(())
          },


### PR DESCRIPTION
Closes #27 

- Refactor Registry to store CommandSpec objects to store completions
- Refactor to pull completer from the keymap
- Forward completion requests to the selected command
- Implement a very basic file completion
- Add *basic* support for handling longer file paths
- Support editing non-existent files

Still TODO:

- [x] Automatically specify command completers based on arg types; `:edit` is already using `PathBuf` so we should be able to take that hint to specify using the `FileCompleter`
