### PR TITLE
Implement f/F "find" motion

### DIFF
--- a/src/editing/motion/char.rs
+++ b/src/editing/motion/char.rs
@@ -2,7 +2,7 @@ use std::cmp::min;
 
 use crate::editing::CursorPosition;
 
-use super::{DirectionalMotion, Motion};
+use super::{DirectionalMotion, Motion, MotionFlags};
 
 /// Character-wise column motion
 pub enum CharMotion {
@@ -20,6 +20,10 @@ impl DirectionalMotion for CharMotion {
 }
 
 impl Motion for CharMotion {
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::EXCLUSIVE
+    }
+
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
         let from = context.cursor();
         match self {

--- a/src/editing/motion/end.rs
+++ b/src/editing/motion/end.rs
@@ -1,9 +1,10 @@
 use crate::editing::CursorPosition;
 
+use super::util::find;
 use super::{
     char::CharMotion,
     linewise::LineCrossing,
-    word::{find, is_not_whitespace},
+    word::is_not_whitespace,
     {DirectionalMotion, Motion},
 };
 

--- a/src/editing/motion/find.rs
+++ b/src/editing/motion/find.rs
@@ -1,6 +1,7 @@
 use crate::editing::CursorPosition;
 
-use super::{char::CharMotion, Motion};
+use super::{char::CharMotion, Motion, MotionFlags};
+use super::{util::search, DirectionalMotion};
 
 pub struct FindMotion {
     step: CharMotion,
@@ -14,10 +15,55 @@ impl FindMotion {
             ch,
         }
     }
+
+    pub fn backward_to(ch: char) -> Self {
+        Self {
+            step: CharMotion::Backward(1),
+            ch,
+        }
+    }
 }
 
 impl Motion for FindMotion {
+    fn flags(&self) -> MotionFlags {
+        if self.step.is_forward() {
+            MotionFlags::NONE
+        } else {
+            MotionFlags::EXCLUSIVE
+        }
+    }
+
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
-        todo!()
+        let (cursor, found) = search(context, context.cursor(), &self.step, |c| {
+            c.chars().next().unwrap() == self.ch
+        });
+        if found {
+            cursor
+        } else {
+            context.cursor()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::editing::motion::tests::window;
+
+    use super::*;
+
+    #[test]
+    fn forward_to_char() {
+        let mut ctx = window("|Take my love");
+
+        ctx.motion(FindMotion::forward_to('l'));
+        ctx.assert_visual_match("Take my |love");
+    }
+
+    #[test]
+    fn backward_to_char() {
+        let mut ctx = window("Take my |love");
+
+        ctx.motion(FindMotion::backward_to('m'));
+        ctx.assert_visual_match("Take |my love");
     }
 }

--- a/src/editing/motion/find.rs
+++ b/src/editing/motion/find.rs
@@ -34,7 +34,7 @@ impl Motion for FindMotion {
     }
 
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
-        let (cursor, found) = search(context, context.cursor(), &self.step, |c| {
+        let (cursor, found) = search(context, self.step.destination(context), &self.step, |c| {
             c.chars().next().unwrap() == self.ch
         });
         if found {
@@ -60,10 +60,42 @@ mod tests {
     }
 
     #[test]
+    fn forward_to_same_char() {
+        let mut ctx = window("Tak|e my love");
+
+        ctx.motion(FindMotion::forward_to('e'));
+        ctx.assert_visual_match("Take my lov|e");
+    }
+
+    #[test]
+    fn forward_to_same_char_adversary() {
+        let mut ctx = window("e|eeeee");
+
+        ctx.motion(FindMotion::forward_to('e'));
+        ctx.assert_visual_match("ee|eeee");
+    }
+
+    #[test]
     fn backward_to_char() {
         let mut ctx = window("Take my |love");
 
         ctx.motion(FindMotion::backward_to('m'));
         ctx.assert_visual_match("Take |my love");
+    }
+
+    #[test]
+    fn backward_to_same_char() {
+        let mut ctx = window("Take my lov|e");
+
+        ctx.motion(FindMotion::backward_to('e'));
+        ctx.assert_visual_match("Tak|e my love");
+    }
+
+    #[test]
+    fn backward_to_same_char_adversary() {
+        let mut ctx = window("eeee|ee");
+
+        ctx.motion(FindMotion::backward_to('e'));
+        ctx.assert_visual_match("eee|eee");
     }
 }

--- a/src/editing/motion/find.rs
+++ b/src/editing/motion/find.rs
@@ -1,0 +1,23 @@
+use crate::editing::CursorPosition;
+
+use super::{char::CharMotion, Motion};
+
+pub struct FindMotion {
+    step: CharMotion,
+    ch: char,
+}
+
+impl FindMotion {
+    pub fn forward_to(ch: char) -> Self {
+        Self {
+            step: CharMotion::Forward(1),
+            ch,
+        }
+    }
+}
+
+impl Motion for FindMotion {
+    fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
+        todo!()
+    }
+}

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -2,6 +2,7 @@ pub mod char;
 pub mod end;
 pub mod find;
 pub mod linewise;
+mod util;
 pub mod word;
 
 use bitflags::bitflags;

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -1,5 +1,6 @@
 pub mod char;
 pub mod end;
+pub mod find;
 pub mod linewise;
 pub mod word;
 

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -100,10 +100,15 @@ pub trait Motion {
     }
 
     fn range<T: MotionContext>(&self, context: &T) -> MotionRange {
-        let start = context.cursor();
-        let end = self.destination(context);
         let flags = self.flags();
         let linewise = flags.contains(MotionFlags::LINEWISE);
+        let inclusive = !flags.contains(MotionFlags::EXCLUSIVE);
+
+        let start = context.cursor();
+        let mut end = self.destination(context);
+        if inclusive {
+            end.col += 1;
+        }
 
         normalize_range(
             context.buffer(),

--- a/src/editing/motion/util.rs
+++ b/src/editing/motion/util.rs
@@ -1,0 +1,44 @@
+use crate::editing::CursorPosition;
+
+use super::Motion;
+
+pub fn search<C: super::MotionContext, M: Motion, P: Fn(&str) -> bool>(
+    context: &C,
+    start: CursorPosition,
+    step: &M,
+    pred: P,
+) -> (CursorPosition, bool) {
+    let mut cursor = start;
+    let mut found = false;
+
+    loop {
+        if let Some(ch) = context.buffer().get_char(cursor) {
+            if pred(ch) {
+                found = true;
+                break;
+            } else {
+                let next = step.destination(&context.with_cursor(cursor));
+                if next == cursor {
+                    // our step didn't move; we can't go further
+                    break;
+                }
+                cursor = next;
+            }
+        } else {
+            // can't go further
+            return (cursor, false);
+        }
+    }
+
+    (cursor, found)
+}
+
+pub fn find<C: super::MotionContext, M: Motion, P: Fn(&str) -> bool>(
+    context: &C,
+    start: CursorPosition,
+    step: &M,
+    pred: P,
+) -> CursorPosition {
+    let (cursor, _) = search(context, start, step, pred);
+    return cursor;
+}

--- a/src/editing/motion/word.rs
+++ b/src/editing/motion/word.rs
@@ -1,5 +1,6 @@
 use crate::editing::CursorPosition;
 
+use super::util::find;
 use super::{char::CharMotion, linewise::LineCrossing, Motion, MotionFlags};
 
 pub fn is_big_word_boundary(ch: &str) -> bool {
@@ -90,35 +91,6 @@ where
 
         cursor
     }
-}
-
-pub fn find<C: super::MotionContext, M: Motion, P: Fn(&str) -> bool>(
-    context: &C,
-    start: CursorPosition,
-    step: &M,
-    pred: P,
-) -> CursorPosition {
-    let mut cursor = start;
-
-    loop {
-        if let Some(ch) = context.buffer().get_char(cursor) {
-            if pred(ch) {
-                break;
-            } else {
-                let next = step.destination(&context.with_cursor(cursor));
-                if next == cursor {
-                    // our step didn't move; we can't go further
-                    break;
-                }
-                cursor = next;
-            }
-        } else {
-            // can't go further
-            return cursor;
-        }
-    }
-
-    cursor
 }
 
 #[cfg(test)]

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -154,6 +154,12 @@ impl Keymap for VimKeymap {
                         .state_mut()
                         .current_buffer_mut()
                         .push_change_key(key);
+
+                    if show_keys {
+                        // NOTE: render here since some key handlers
+                        // also read from keysource
+                        self.render_keys_buffer(context);
+                    }
                 }
 
                 if let Some(next) = current.children.get(&key) {

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -344,26 +344,38 @@ macro_rules! vim_branches {
     (
         $root:ident ->
         $keys:literal =>
-            motion $factory:expr,
+            motion |$ctx_name:ident| $factory:expr,
         $($tail:tt)*
     ) => {
-        $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |ctx| {
+        $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |$ctx_name| {
             use crate::editing::motion::Motion;
             let motion = $factory;
-            let operator_fn = ctx.keymap.operator_fn.take();
-            ctx.keymap.reset(); // always clear
+            let operator_fn = $ctx_name.keymap.operator_fn.take();
+            $ctx_name.keymap.reset(); // always clear
 
             if let Some(op) = operator_fn {
                 // execute pending operator fn
-                let range = motion.range(ctx.state());
-                op(ctx, range)
+                let range = motion.range($ctx_name.state());
+                op($ctx_name, range)
             } else {
                 // no operator fn? just move the cursor
-                motion.apply_cursor(ctx.state_mut());
+                motion.apply_cursor($ctx_name.state_mut());
                 Ok(())
             }
         }));
         crate::vim_branches! { $root -> $($tail)* }
+    };
+
+    (
+        $root:ident ->
+        $keys:literal =>
+            motion $factory:expr,
+        $($tail:tt)*
+    ) => {
+        crate::vim_branches! { $root ->
+            $keys => motion |ctx| $factory,
+            $($tail)*
+        };
     };
 }
 

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -36,13 +36,13 @@ pub fn vim_standard_motions() -> KeyTreeNode {
         "f" => motion |ctx| {
             match ctx.next_key()? {
                 Some(Key { code: KeyCode::Char(ch), .. }) => FindMotion::forward_to(ch),
-                _ =>{  return Ok(()); }
+                _ => return Ok(()),
             }
         },
         "F" => motion |ctx| {
             match ctx.next_key()? {
                 Some(Key { code: KeyCode::Char(ch), .. }) => FindMotion::backward_to(ch),
-                _ =>{  return Ok(()); }
+                _ => return Ok(()),
             }
         },
     }

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -39,6 +39,12 @@ pub fn vim_standard_motions() -> KeyTreeNode {
                 _ =>{  return Ok(()); }
             }
         },
+        "F" => motion |ctx| {
+            match ctx.context.next_key()? {
+                Some(Key { code: KeyCode::Char(ch), .. }) => FindMotion::backward_to(ch),
+                _ =>{  return Ok(()); }
+            }
+        },
     }
 }
 

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -1,9 +1,10 @@
 use crate::input::maps::vim::VimKeymap;
-use crate::input::KeymapContext;
+use crate::input::{Key, KeyCode, KeymapContext};
 use crate::vim_tree;
 use crate::{
     editing::motion::char::CharMotion,
     editing::motion::end::EndOfWordMotion,
+    editing::motion::find::FindMotion,
     editing::motion::linewise::{
         DownLineMotion, ToFirstLineMotion, ToLastLineMotion, ToLineEndMotion, ToLineStartMotion,
         UpLineMotion,
@@ -31,6 +32,13 @@ pub fn vim_standard_motions() -> KeyTreeNode {
 
         "0" => motion { ToLineStartMotion },
         "$" => motion { ToLineEndMotion },
+
+        "f" => motion |ctx| {
+            match ctx.context.next_key()? {
+                Some(Key { code: KeyCode::Char(ch), .. }) => FindMotion::forward_to(ch),
+                _ =>{  return Ok(()); }
+            }
+        },
     }
 }
 

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -1,5 +1,5 @@
 use crate::input::maps::vim::VimKeymap;
-use crate::input::{Key, KeyCode, KeymapContext};
+use crate::input::{Key, KeyCode, KeySource, KeymapContext};
 use crate::vim_tree;
 use crate::{
     editing::motion::char::CharMotion,
@@ -34,13 +34,13 @@ pub fn vim_standard_motions() -> KeyTreeNode {
         "$" => motion { ToLineEndMotion },
 
         "f" => motion |ctx| {
-            match ctx.context.next_key()? {
+            match ctx.next_key()? {
                 Some(Key { code: KeyCode::Char(ch), .. }) => FindMotion::forward_to(ch),
                 _ =>{  return Ok(()); }
             }
         },
         "F" => motion |ctx| {
-            match ctx.context.next_key()? {
+            match ctx.next_key()? {
                 Some(Key { code: KeyCode::Char(ch), .. }) => FindMotion::backward_to(ch),
                 _ =>{  return Ok(()); }
             }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -296,4 +296,62 @@ mod tests {
             "});
         }
     }
+
+    #[cfg(test)]
+    mod f {
+        use super::*;
+
+        #[test]
+        fn find_char() {
+            let ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.feed_vim("fl").assert_visual_match(indoc! {"
+                Take my love
+                Take my |land
+                Take me where
+            "});
+        }
+
+        #[test]
+        fn find_non_matching_does_not_move() {
+            let ctx = window(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+            ctx.feed_vim("fz").assert_visual_match(indoc! {"
+                Take my love
+                |Take my land
+                Take me where
+            "});
+        }
+    }
+
+    #[cfg(test)]
+    mod capital_f {
+        use super::*;
+
+        #[test]
+        fn find_char() {
+            let ctx = window(indoc! {"
+                Take my |land
+            "});
+            ctx.feed_vim("Fe").assert_visual_match(indoc! {"
+                Tak|e my land
+            "});
+        }
+
+        #[test]
+        fn find_non_matching_does_not_move() {
+            let ctx = window(indoc! {"
+                Take my |land
+            "});
+            ctx.feed_vim("Fz").assert_visual_match(indoc! {"
+                Take my |land
+            "});
+        }
+    }
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -222,6 +222,26 @@ mod tests {
         }
 
         #[test]
+        fn dh() {
+            let ctx = window(indoc! {"
+                Take my l|and
+            "});
+            ctx.feed_vim("dh").assert_visual_match(indoc! {"
+                Take my |and
+            "});
+        }
+
+        #[test]
+        fn dl() {
+            let ctx = window(indoc! {"
+                Take my |land
+            "});
+            ctx.feed_vim("dl").assert_visual_match(indoc! {"
+                Take my |and
+            "});
+        }
+
+        #[test]
         fn follows_exclusive_line_cross_exception() {
             // see :help exclusive in vim
             let ctx = window(indoc! {"
@@ -304,28 +324,30 @@ mod tests {
         #[test]
         fn find_char() {
             let ctx = window(indoc! {"
-                Take my love
                 |Take my land
-                Take me where
             "});
             ctx.feed_vim("fl").assert_visual_match(indoc! {"
-                Take my love
                 Take my |land
-                Take me where
             "});
         }
 
         #[test]
         fn find_non_matching_does_not_move() {
             let ctx = window(indoc! {"
-                Take my love
                 |Take my land
-                Take me where
             "});
             ctx.feed_vim("fz").assert_visual_match(indoc! {"
-                Take my love
                 |Take my land
-                Take me where
+            "});
+        }
+
+        #[test]
+        fn delete_with_find() {
+            let ctx = window(indoc! {"
+                |Take my land
+            "});
+            ctx.feed_vim("dfl").assert_visual_match(indoc! {"
+                |and
             "});
         }
     }
@@ -350,6 +372,26 @@ mod tests {
                 Take my |land
             "});
             ctx.feed_vim("Fz").assert_visual_match(indoc! {"
+                Take my |land
+            "});
+        }
+
+        #[test]
+        fn delete_with_find() {
+            let ctx = window(indoc! {"
+                Take my |land
+            "});
+            ctx.feed_vim("dFm").assert_visual_match(indoc! {"
+                Take |land
+            "});
+        }
+
+        #[test]
+        fn delete_with_non_matching() {
+            let ctx = window(indoc! {"
+                Take my |land
+            "});
+            ctx.feed_vim("dFz").assert_visual_match(indoc! {"
                 Take my |land
             "});
         }


### PR DESCRIPTION
- Scaffold out FindMotion
- Implement find motion
- Fix: key buffer not rendering the `f`/`F` keys
- Fix range for find motions by improving exclusive motion range
- Minor style cleanup
- Handle some more find motion edge cases
