### PR TITLE
Add initial key remap support

### DIFF
--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -69,13 +69,13 @@ fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyRes
 
 #[cfg(test)]
 mod tests {
-    use crate::editing::motion::tests::TestKeymapContext;
+    use crate::editing::motion::tests::TestKeyHandlerContext;
 
     use super::*;
 
     #[test]
     fn quit_single_windows_test() -> KeyResult {
-        let mut context = TestKeymapContext::empty();
+        let mut context = TestKeyHandlerContext::empty();
         let mut ctx = context.command_context("q");
         ctx.state_mut().current_tab_mut().vsplit();
 
@@ -91,7 +91,7 @@ mod tests {
 
     #[test]
     fn quit_connection_window_test() -> KeyResult {
-        let mut context = TestKeymapContext::empty();
+        let mut context = TestKeyHandlerContext::empty();
         let mut ctx = context.command_context("q");
 
         let state = ctx.state_mut();

--- a/src/input/commands/helpers.rs
+++ b/src/input/commands/helpers.rs
@@ -96,7 +96,7 @@ mod tests {
     #[cfg(test)]
     mod check_hide_buffer {
         use crate::editing::FocusDirection;
-        use crate::{connection::Connection, editing::motion::tests::TestKeymapContext};
+        use crate::{connection::Connection, editing::motion::tests::TestKeyHandlerContext};
 
         use super::*;
 
@@ -118,7 +118,7 @@ mod tests {
 
         #[test]
         fn disallow_hiding_connlayout() -> KeyResult {
-            let mut context = TestKeymapContext::empty();
+            let mut context = TestKeyHandlerContext::empty();
             let mut ctx = context.command_context("q");
 
             let state = ctx.state_mut();

--- a/src/input/commands/mod.rs
+++ b/src/input/commands/mod.rs
@@ -17,19 +17,25 @@ use self::{
     log::declare_log, registry::CommandRegistry, window::declare_window,
 };
 
-use super::{maps::KeyResult, KeySource, KeymapContext};
+use super::{maps::KeyResult, BoxableKeymap, KeySource, KeymapContext};
 
 pub type CommandHandler = dyn Fn(&mut CommandHandlerContext<'_>) -> KeyResult;
 
 pub struct CommandHandlerContext<'a> {
     pub context: Box<&'a mut dyn KeymapContext>,
+    pub keymap: Box<&'a mut dyn BoxableKeymap>,
     pub input: String,
 }
 
 impl<'a> CommandHandlerContext<'a> {
-    pub fn new<T: KeymapContext>(context: &'a mut T, input: String) -> Self {
+    pub fn new<T: KeymapContext, K: BoxableKeymap>(
+        context: &'a mut T,
+        keymap: &'a mut K,
+        input: String,
+    ) -> Self {
         Self {
             context: Box::new(context),
+            keymap: Box::new(keymap),
             input,
         }
     }

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -17,7 +17,7 @@ pub struct KeyHandlerContext<'a, T> {
 }
 
 impl<T: Keymap> KeyHandlerContext<'_, T> {
-    fn feed_keys(mut self, keys: Vec<Key>) -> Result<Self, KeyError> {
+    pub fn feed_keys(mut self, keys: Vec<Key>) -> Result<Self, KeyError> {
         let source = MemoryKeySource::from(keys);
         let mut context = KeymapContextWithKeys::new(self.context, source);
 

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     editing::motion::MotionRange,
     input::{
         completion::{state::BoxedCompleter, Completer},
-        Key, KeyError, Keymap, KeymapContext, RemapMode, Remappable,
+        BoxableKeymap, Key, KeyError, Keymap, KeymapContext, RemapMode, Remappable,
     },
 };
 
@@ -250,6 +250,12 @@ impl Keymap for VimKeymap {
         }
 
         result
+    }
+}
+
+impl BoxableKeymap for VimKeymap {
+    fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>) {
+        crate::input::remap_keys_to_fn(self, mode, from, to)
     }
 }
 

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -72,7 +72,7 @@ fn mappings(config: VimPromptConfig) -> KeyTreeNode {
              ctx.state_mut().prompt.clear();
 
              // submit to handler
-             (config.handler)(&mut CommandHandlerContext::new(&mut ctx, input))
+             (config.handler)(&mut CommandHandlerContext::new(&mut ctx.context, ctx.keymap, input))
          },
     }
 }

--- a/src/input/maps/vim/tree.rs
+++ b/src/input/maps/vim/tree.rs
@@ -1,13 +1,14 @@
-use std::{collections::HashMap, ops};
+use std::{collections::HashMap, ops, rc::Rc};
 
 use crate::input::Key;
 
 use super::KeyHandler;
 
+#[derive(Clone)]
 pub struct KeyTreeNode {
     pub children: HashMap<Key, KeyTreeNode>,
-    handler: Option<Box<KeyHandler>>,
-    handler_override: Option<Box<KeyHandler>>,
+    handler: Option<Rc<KeyHandler>>,
+    handler_override: Option<Rc<KeyHandler>>,
 }
 
 impl KeyTreeNode {
@@ -19,7 +20,7 @@ impl KeyTreeNode {
         }
     }
 
-    pub fn get_handler(&self) -> Option<&Box<KeyHandler>> {
+    pub fn get_handler(&self) -> Option<&Rc<KeyHandler>> {
         if let Some(overridden) = &self.handler_override {
             Some(overridden)
         } else if let Some(handler) = &self.handler {
@@ -31,7 +32,7 @@ impl KeyTreeNode {
 
     pub fn insert(&mut self, keys: &[Key], handler: Box<KeyHandler>) {
         if keys.is_empty() {
-            self.handler = Some(handler);
+            self.handler = Some(Rc::new(handler));
         } else {
             let first_key = keys[0];
             let node = self

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -135,10 +135,6 @@ pub enum RemapMode {
     User(String),
 }
 
-pub trait BoxableKeymap {
-    fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
-}
-
 pub fn remap_keys_to_fn<K: Keymap, R: Remappable<K>>(
     keymap: &mut R,
     mode: RemapMode,
@@ -157,6 +153,10 @@ pub fn remap_keys_to_fn<K: Keymap, R: Remappable<K>>(
 
 pub trait Remappable<T: Keymap>: BoxableKeymap {
     fn remap_keys_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<KeyHandler<T>>);
+}
+
+pub trait BoxableKeymap {
+    fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
 }
 
 impl BoxableKeymap for Box<&mut dyn BoxableKeymap> {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -117,11 +117,9 @@ pub enum RemapMode {
     User(String),
 }
 
-pub trait Remappable<T> {
+pub trait Remappable<T: Keymap> {
     fn remap_keys_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<KeyHandler<T>>);
-}
 
-impl<T: Keymap> dyn Remappable<T> {
     fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>) {
         self.remap_keys_fn(
             mode,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ pub mod log;
 
 use app::looper::app_loop;
 use backtrace::Backtrace;
-use input::{keys::KeysParsable, maps::vim::VimKeymap, RemapMode, Remappable};
+use input::{keys::KeysParsable, maps::vim::VimKeymap, BoxableKeymap, RemapMode};
 use std::{
     io, panic,
     sync::{Arc, Mutex},

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ pub mod log;
 
 use app::looper::app_loop;
 use backtrace::Backtrace;
-use input::maps::vim::VimKeymap;
+use input::{keys::KeysParsable, maps::vim::VimKeymap, RemapMode, Remappable};
 use std::{
     io, panic,
     sync::{Arc, Mutex},
@@ -43,7 +43,14 @@ fn main_loop() -> io::Result<()> {
         ToLineEndMotion.apply_cursor(&mut app.state);
     }
 
-    app_loop(app, tui::events::TuiEvents::default(), VimKeymap::default());
+    let mut keymap = VimKeymap::default();
+    keymap.remap_keys(
+        RemapMode::VimNormal,
+        "gc".into_keys(),
+        ":connect ".into_keys(),
+    );
+
+    app_loop(app, tui::events::TuiEvents::default(), keymap);
 
     Ok(())
 }


### PR DESCRIPTION
The user mappings ended up not being stored alongside the base mappings
(those are just built up as-needed instead of being stored, anyway), so we can
probably get rid of the `handler_override` stuff.

- Build initial support for remapping keys
- Move remap_keys into the Remappable trait as a default impl
- Temporarily stub some remapping in main
- Refactor CommandHandlerContext to be able to access remapping

We had to work around a few things:

1. Keymap really needs `process` to be a generic method, to accept any kind
   of KeymapContext. Trying to make it accept a `Box<dyn KeymapContext>`
   doesn't work out well due to lifetime confusion
2. Because of (1), `Keymap` cannot be used as a trait object, so adding
   things like remap to it directly fail pretty hard
3. The above could be easily worked around if we didn't need Commands and
   other keymap-agnostic code to access remap at some point.

To solve this, we introduce `BoxableKeymap` to serve as a generic-agnostic
intrface to the keymap, which *can* be boxed and stored in the
`CommandHandlerContext`. This trait generally delegates to
`Remappable<Keymap>` to store a `KeyHandler` of the appropriate type. This
allows us synchronous access to mappings, so we can get feedback if, for
example, an `unmap` might would actually remove a mapping or not.

Remap Command implementation is deferred for now; this is a foundational PR.
