### PR TITLE
Add basic support for in-buffer search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -264,9 +264,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytemuck"
-version = "1.5.1"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bed57e2090563b83ba8f83366628ce535a7584c9afa4c9fc0612a03925c6df58"
+checksum = "72957246c41db82b8ef88a5486143830adeb8227ef9837740bdec67724cf2c5b"
 
 [[package]]
 name = "byteorder"
@@ -340,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "clipboard-win"
-version = "4.1.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dc138eac3ade40f10cb7aee8b27e6aed1342d8788c40e66eb52914009d160ed"
+checksum = "4e4ea1881992efc993e4dc50a324cdbd03216e41bdc8385720ff47efc9bd2ca8"
 dependencies = [
  "error-code",
  "str-buf",
@@ -648,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d4871041f3339e2cd4a23c698f89519e1ca62aa73190eddcc18dde4ee11e8ff"
+checksum = "b5115567ac25674e0043e472be13d14e537f37ea8aa4bdc4aef0c89add1db1ff"
 dependencies = [
  "libc",
  "str-buf",
@@ -1016,9 +1016,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.93"
+version = "0.2.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
+checksum = "3cb00336871be5ed2c8ed44b60ae9959dc5b9f08539422ed43f09e34ecaeba21"
 
 [[package]]
 name = "libz-sys"
@@ -1093,6 +1093,15 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "memoffset"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -1176,14 +1185,15 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa9b4819da1bc61c0ea48b63b7bc8604064dd43013e7cc325df098d49cd7c18a"
+checksum = "df8e5e343312e7fbeb2a52139114e9e702991ef9c2aea6817ff2440b35647d56"
 dependencies = [
  "bitflags",
  "cc",
  "cfg-if 1.0.0",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2158,9 +2168,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "str-buf"
-version = "2.0.0"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66ae6a6cd930c97707cb3f1b62aadb8ddddd2fefa9df539564b3bfaa15dd31f"
+checksum = "d44a3643b4ff9caf57abcee9c2c621d6c03d9135e0d8b589bd9afb5992cb176a"
 
 [[package]]
 name = "string_cache"
@@ -2742,7 +2752,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ffb080b3f2f616242a4eb8e7d325035312127901025b0052bc3154a282d0f19"
 dependencies = [
  "gethostname",
- "nix 0.20.0",
+ "nix 0.20.1",
  "winapi",
  "winapi-wsapoll",
 ]

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -2,6 +2,7 @@ pub mod char;
 pub mod end;
 pub mod find;
 pub mod linewise;
+pub mod search;
 mod util;
 pub mod word;
 

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -208,6 +208,7 @@ pub mod tests {
     };
 
     use super::*;
+    use std::any::Any;
 
     pub struct TestKeymapContext {
         keys: MemoryKeySource,
@@ -233,6 +234,10 @@ pub mod tests {
             _handler: Box<crate::input::maps::UserKeyHandler>,
         ) {
             todo!()
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
         }
     }
 

--- a/src/editing/motion/search.rs
+++ b/src/editing/motion/search.rs
@@ -13,17 +13,17 @@ pub struct SearchMotion {
 }
 
 impl SearchMotion {
-    pub fn backward_until(query: String) -> Self {
+    pub fn backward_until<T: Into<String>>(query: T) -> Self {
         Self {
             step: LineCrossing::new(CharMotion::Backward(1)),
-            query,
+            query: query.into(),
         }
     }
 
-    pub fn forward_until(query: String) -> Self {
+    pub fn forward_until<T: Into<String>>(query: T) -> Self {
         Self {
             step: LineCrossing::new(CharMotion::Forward(1)),
-            query,
+            query: query.into(),
         }
     }
 }
@@ -44,18 +44,19 @@ impl Motion for SearchMotion {
 
         loop {
             let (next_cursor, found) = search(context, cursor, &self.step, |c| c == first_char);
-            if !found {
+            if !found || next_cursor == cursor {
                 return origin;
             }
 
             cursor = next_cursor;
             let line = context.buffer().get(cursor.line);
-            if line.width() < cursor.col + self.query.len() {
+            let end = cursor.col + self.query.len();
+            if line.width() < end {
                 // Cannot possibly be a match
                 continue;
             }
 
-            let candidate = line.subs(cursor.col, self.query.len());
+            let candidate = line.subs(cursor.col, end);
             if candidate.starts_with(&self.query) {
                 // Found it! Return the cursor
                 break;
@@ -63,5 +64,53 @@ impl Motion for SearchMotion {
         }
 
         cursor
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::editing::motion::tests::window;
+    use indoc::indoc;
+
+    mod forward_search {
+        use super::*;
+
+        #[test]
+        fn within_line() {
+            let mut ctx = window(indoc! {"
+                |Take my land
+            "});
+            ctx.motion(SearchMotion::forward_until("my"));
+            ctx.assert_visual_match(indoc! {"
+                Take |my land
+            "});
+        }
+
+        #[test]
+        fn dont_move_without_match() {
+            let mut ctx = window(indoc! {"
+                |Take my land
+            "});
+            ctx.motion(SearchMotion::forward_until("alright"));
+            ctx.assert_visual_match(indoc! {"
+                |Take my land
+            "});
+        }
+    }
+
+    mod backward_search {
+        use super::*;
+
+        #[test]
+        fn within_line() {
+            let mut ctx = window(indoc! {"
+                Take my |land
+            "});
+            ctx.motion(SearchMotion::backward_until("my"));
+            ctx.assert_visual_match(indoc! {"
+                Take |my land
+            "});
+        }
     }
 }

--- a/src/editing/motion/search.rs
+++ b/src/editing/motion/search.rs
@@ -1,0 +1,67 @@
+use crate::editing::motion::char::CharMotion;
+use crate::editing::motion::linewise::LineCrossing;
+use crate::editing::motion::Motion;
+use crate::editing::motion::MotionFlags;
+use crate::editing::text::EditableLine;
+use crate::editing::CursorPosition;
+
+use super::util::search;
+
+pub struct SearchMotion {
+    step: LineCrossing<CharMotion>,
+    query: String,
+}
+
+impl SearchMotion {
+    pub fn backward_until(query: String) -> Self {
+        Self {
+            step: LineCrossing::new(CharMotion::Backward(1)),
+            query,
+        }
+    }
+
+    pub fn forward_until(query: String) -> Self {
+        Self {
+            step: LineCrossing::new(CharMotion::Forward(1)),
+            query,
+        }
+    }
+}
+
+impl Motion for SearchMotion {
+    fn flags(&self) -> MotionFlags {
+        MotionFlags::EXCLUSIVE
+    }
+
+    fn destination<C: super::MotionContext>(&self, context: &C) -> CursorPosition {
+        if context.buffer().lines_count() == 0 {
+            return context.cursor();
+        }
+
+        let origin = context.cursor();
+        let mut cursor = self.step.destination(context);
+        let first_char = &self.query[0..1];
+
+        loop {
+            let (next_cursor, found) = search(context, cursor, &self.step, |c| c == first_char);
+            if !found {
+                return origin;
+            }
+
+            cursor = next_cursor;
+            let line = context.buffer().get(cursor.line);
+            if line.width() < cursor.col + self.query.len() {
+                // Cannot possibly be a match
+                continue;
+            }
+
+            let candidate = line.subs(cursor.col, self.query.len());
+            if candidate.starts_with(&self.query) {
+                // Found it! Return the cursor
+                break;
+            }
+        }
+
+        cursor
+    }
+}

--- a/src/input/history.rs
+++ b/src/input/history.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+
+pub struct History<T> {
+    pub items: Vec<T>,
+}
+
+impl<T> History<T> {
+    pub fn first(&self) -> Option<&T> {
+        self.items.get(0)
+    }
+
+    pub fn insert(&mut self, item: T) {
+        // TODO History limits
+        self.items.insert(0, item)
+    }
+}
+
+impl<T> Default for History<T> {
+    fn default() -> Self {
+        Self {
+            items: Default::default(),
+        }
+    }
+}
+
+#[derive(Default)]
+pub struct StringHistories {
+    histories: HashMap<String, History<String>>,
+}
+
+impl StringHistories {
+    pub fn get(&mut self, key: String) -> &mut History<String> {
+        self.histories
+            .entry(key)
+            .or_insert_with(|| Default::default())
+    }
+
+    pub fn get_most_recent(&self, key: String) -> Option<&String> {
+        if let Some(history) = self.histories.get(&key) {
+            history.first()
+        } else {
+            None
+        }
+    }
+
+    pub fn maybe_insert(&mut self, key: String, entry: String) {
+        let history = self.get(key);
+        if let Some(existing) = history.first() {
+            if existing.to_owned() == entry {
+                return;
+            }
+        }
+
+        history.insert(entry)
+    }
+}

--- a/src/input/history.rs
+++ b/src/input/history.rs
@@ -1,25 +1,42 @@
+use std::collections::vec_deque::Iter;
 use std::collections::HashMap;
+use std::collections::VecDeque;
+
+const DEFAULT_HISTORY_LIMIT: usize = 10000;
 
 pub struct History<T> {
-    pub items: Vec<T>,
+    items: VecDeque<T>,
+    pub limit: usize,
 }
 
 impl<T> History<T> {
+    pub fn with_limit(limit: usize) -> Self {
+        Self {
+            items: Default::default(),
+            limit,
+        }
+    }
+
     pub fn first(&self) -> Option<&T> {
         self.items.get(0)
     }
 
     pub fn insert(&mut self, item: T) {
-        // TODO History limits
-        self.items.insert(0, item)
+        while self.items.len() >= self.limit {
+            self.items.pop_back();
+        }
+        self.items.push_front(item);
+    }
+
+    #[allow(dead_code)] // NOTE: We use it in a test, and will need it later
+    pub fn iter(&self) -> Iter<T> {
+        self.items.iter()
     }
 }
 
 impl<T> Default for History<T> {
     fn default() -> Self {
-        Self {
-            items: Default::default(),
-        }
+        Self::with_limit(DEFAULT_HISTORY_LIMIT)
     }
 }
 
@@ -52,5 +69,20 @@ impl StringHistories {
         }
 
         history.insert(entry)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn history_limit() {
+        let mut history = History::<&str>::with_limit(2);
+        history.insert("First");
+        history.insert("Second");
+        history.insert("Third");
+        let contents: Vec<String> = history.iter().map(|s| s.to_string()).collect();
+        assert_eq!(contents, vec!["Third", "Second"]);
     }
 }

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -1,10 +1,12 @@
 mod insert;
 mod mode_stack;
+mod motion;
 mod motions;
 mod normal;
 mod prompt;
 mod tree;
 
+use std::any::Any;
 use std::{collections::HashMap, ops, rc::Rc};
 
 use insert::vim_insert_mode;
@@ -270,6 +272,9 @@ impl BoxableKeymap for VimKeymap {
             }),
         );
     }
+    fn as_any_mut(&mut self) -> &mut dyn Any {
+        self
+    }
 }
 
 impl Remappable<VimKeymap> for VimKeymap {
@@ -422,24 +427,21 @@ macro_rules! vim_branches {
         $($tail:tt)*
     ) => {
         $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |$ctx_name| {
-            use crate::editing::motion::Motion;
             let motion = $factory;
-            let operator_fn = $ctx_name.keymap.operator_fn.take();
+            crate::input::maps::vim::motion::apply_motion($ctx_name, motion)
+        }));
+        crate::vim_branches! { $root -> $($tail)* }
+    };
 
-            let result = if let Some(op) = operator_fn {
-                // execute pending operator fn
-                let range = motion.range($ctx_name.state());
-                op(&mut $ctx_name, range)
-            } else {
-                // no operator fn? just move the cursor
-                motion.apply_cursor($ctx_name.state_mut());
-                Ok(())
-            };
-
-            // Always reset state *after* executing the operator
-            $ctx_name.keymap.reset();
-
-            result
+    (
+        $root:ident ->
+        $keys:literal =>
+            motion |?mut $ctx_name:ident| $factory:expr,
+        $($tail:tt)*
+    ) => {
+        $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |?mut $ctx_name| {
+            let motion = $factory;
+            crate::input::maps::vim::motion::apply_motion($ctx_name, motion)
         }));
         crate::vim_branches! { $root -> $($tail)* }
     };
@@ -451,7 +453,7 @@ macro_rules! vim_branches {
         $($tail:tt)*
     ) => {
         crate::vim_branches! { $root ->
-            $keys => motion |ctx| $factory,
+            $keys => motion |?mut ctx| $factory,
             $($tail)*
         };
     };

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -19,6 +19,8 @@ use crate::{
     input::{
         commands::CommandHandlerContext,
         completion::{state::BoxedCompleter, Completer},
+        history::StringHistories,
+        maps::vim::normal::search::VimSearchState,
         BoxableKeymap, Key, KeyError, Keymap, KeymapContext, RemapMode, Remappable,
     },
 };
@@ -109,6 +111,8 @@ pub struct VimKeymap {
     pub selected_register: Option<char>,
     active_completer: Option<Rc<dyn Completer>>,
     user_maps: HashMap<RemapMode, KeyTreeNode>,
+    pub histories: StringHistories,
+    pub search: VimSearchState,
 }
 
 impl VimKeymap {

--- a/src/input/maps/vim/motion.rs
+++ b/src/input/maps/vim/motion.rs
@@ -4,7 +4,15 @@ use crate::input::maps::KeyResult;
 use crate::input::KeymapContext;
 use crate::VimKeymap;
 
-pub fn apply_motion<T: Motion>(mut ctx: KeyHandlerContext<VimKeymap>, motion: T) -> KeyResult {
+pub fn apply_motion<T: Motion>(ctx: KeyHandlerContext<VimKeymap>, motion: T) -> KeyResult {
+    let (_, result) = apply_motion_returning(ctx, motion);
+    return result;
+}
+
+pub fn apply_motion_returning<T: Motion>(
+    mut ctx: KeyHandlerContext<VimKeymap>,
+    motion: T,
+) -> (KeyHandlerContext<VimKeymap>, KeyResult) {
     let operator_fn = ctx.keymap.operator_fn.take();
 
     let result = if let Some(op) = operator_fn {
@@ -20,5 +28,5 @@ pub fn apply_motion<T: Motion>(mut ctx: KeyHandlerContext<VimKeymap>, motion: T)
     // Always reset state *after* executing the operator
     ctx.keymap.reset();
 
-    result
+    (ctx, result)
 }

--- a/src/input/maps/vim/motion.rs
+++ b/src/input/maps/vim/motion.rs
@@ -1,0 +1,24 @@
+use crate::editing::motion::Motion;
+use crate::input::maps::KeyHandlerContext;
+use crate::input::maps::KeyResult;
+use crate::input::KeymapContext;
+use crate::VimKeymap;
+
+pub fn apply_motion<T: Motion>(mut ctx: KeyHandlerContext<VimKeymap>, motion: T) -> KeyResult {
+    let operator_fn = ctx.keymap.operator_fn.take();
+
+    let result = if let Some(op) = operator_fn {
+        // execute pending operator fn
+        let range = motion.range(ctx.state());
+        op(&mut ctx, range)
+    } else {
+        // no operator fn? just move the cursor
+        motion.apply_cursor(ctx.state_mut());
+        Ok(())
+    };
+
+    // Always reset state *after* executing the operator
+    ctx.keymap.reset();
+
+    result
+}

--- a/src/input/maps/vim/motions.rs
+++ b/src/input/maps/vim/motions.rs
@@ -1,5 +1,5 @@
 use crate::input::maps::vim::VimKeymap;
-use crate::input::{Key, KeyCode, KeySource, KeymapContext};
+use crate::input::{Key, KeyCode, KeySource};
 use crate::vim_tree;
 use crate::{
     editing::motion::char::CharMotion,

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,6 +1,7 @@
 mod change;
 mod registers;
 mod scroll;
+mod search;
 mod window;
 
 use std::rc::Rc;
@@ -130,6 +131,7 @@ pub fn vim_normal_mode() -> VimMode {
         + change::mappings()
         + registers::mappings()
         + scroll::mappings()
+        + search::mappings()
         + window::mappings()
         + vim_standard_motions()
         + vim_linewise_motions();

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -1,7 +1,7 @@
 mod change;
 mod registers;
 mod scroll;
-mod search;
+pub mod search;
 mod window;
 
 use std::rc::Rc;

--- a/src/input/maps/vim/normal/search.rs
+++ b/src/input/maps/vim/normal/search.rs
@@ -79,6 +79,11 @@ fn handle_search_result<C: KeymapContext>(
 
 fn handle_search(context: &mut CommandHandlerContext, ui: char, motion: SearchMotion) -> KeyResult {
     let query = context.input.to_string();
+    if query.len() == 0 {
+        // TODO Repeat the last search
+        return Ok(());
+    }
+
     context.state_mut().echo(format!("{}{}", ui, query).into());
 
     let initial_cursor = context.state().current_window().cursor;

--- a/src/input/maps/vim/normal/search.rs
+++ b/src/input/maps/vim/normal/search.rs
@@ -1,53 +1,77 @@
-use crate::editing::FocusDirection;
+use crate::editing::motion::search::SearchMotion;
+use crate::input::commands::CommandHandler;
+use crate::input::maps::vim::motion::apply_motion;
 use crate::input::maps::vim::prompt::VimPromptConfig;
 use crate::input::maps::vim::tree::KeyTreeNode;
 use crate::input::maps::vim::VimKeymap;
 use crate::input::maps::CommandHandlerContext;
 use crate::input::maps::KeyError;
+use crate::input::maps::KeyHandlerContext;
 use crate::input::maps::KeyResult;
 use crate::input::KeymapContext;
 use crate::vim_tree;
 
-fn handle_search(context: &mut CommandHandlerContext, _direction: FocusDirection) -> KeyResult {
-    // TODO
-    context.state_mut().echo_str("TODO: search");
-    Ok(())
+fn handle_search(context: &mut CommandHandlerContext, ui: char, motion: SearchMotion) -> KeyResult {
+    let query = context.input.to_string();
+    context.state_mut().echo(format!("{}{}", ui, query).into());
+
+    if let Some(keymap) = context.keymap.as_any_mut().downcast_mut::<VimKeymap>() {
+        let ctx = KeyHandlerContext {
+            context: Box::new(&mut context.context),
+            keymap,
+            key: "<cr>".into(),
+        };
+        apply_motion(ctx, motion)
+    } else {
+        // This shouldn't be possible:
+        panic!("Performing vim search without VimKeymap")
+    }
 }
 
 fn handle_forward_search(context: &mut CommandHandlerContext) -> KeyResult {
-    handle_search(context, FocusDirection::Down)
+    handle_search(
+        context,
+        '/',
+        SearchMotion::forward_until(context.input.to_string()),
+    )
 }
 
-fn handle_reverse_search(context: &mut CommandHandlerContext) -> KeyResult {
-    handle_search(context, FocusDirection::Up)
+fn handle_backward_search(context: &mut CommandHandlerContext) -> KeyResult {
+    handle_search(
+        context,
+        '?',
+        SearchMotion::backward_until(context.input.to_string()),
+    )
+}
+
+fn activate_search(
+    mut ctx: KeyHandlerContext<VimKeymap>,
+    ui: char,
+    handler: Box<CommandHandler>,
+) -> KeyResult {
+    ctx.state_mut().clear_echo();
+    ctx.state_mut().prompt.activate(ui.to_string().into());
+
+    ctx.keymap.push_mode(
+        VimPromptConfig {
+            prompt: ui.to_string(),
+            handler,
+            completer: None,
+        }
+        .into(),
+    );
+
+    Ok(())
 }
 
 pub fn mappings() -> KeyTreeNode {
     vim_tree! {
-        "/" => |ctx| {
-            ctx.state_mut().clear_echo();
-            ctx.state_mut().prompt.activate("/".into());
-
-            ctx.keymap.push_mode(VimPromptConfig{
-                prompt: "/".into(),
-                handler: Box::new(handle_forward_search),
-                completer: None,
-            }.into());
-
-            Ok(())
+        "/" => |?mut ctx| {
+            activate_search(ctx, '/', Box::new(handle_forward_search))
         },
 
-        "?" => |ctx| {
-            ctx.state_mut().clear_echo();
-            ctx.state_mut().prompt.activate("?".into());
-
-            ctx.keymap.push_mode(VimPromptConfig{
-                prompt: "?".into(),
-                handler: Box::new(handle_reverse_search),
-                completer: None,
-            }.into());
-
-            Ok(())
+        "?" => |?mut ctx| {
+            activate_search(ctx, '?', Box::new(handle_backward_search))
         },
 
         "n" => |?mut _ctx| {

--- a/src/input/maps/vim/normal/search.rs
+++ b/src/input/maps/vim/normal/search.rs
@@ -1,0 +1,61 @@
+use crate::editing::FocusDirection;
+use crate::input::maps::vim::prompt::VimPromptConfig;
+use crate::input::maps::vim::tree::KeyTreeNode;
+use crate::input::maps::vim::VimKeymap;
+use crate::input::maps::CommandHandlerContext;
+use crate::input::maps::KeyError;
+use crate::input::maps::KeyResult;
+use crate::input::KeymapContext;
+use crate::vim_tree;
+
+fn handle_search(context: &mut CommandHandlerContext, _direction: FocusDirection) -> KeyResult {
+    // TODO
+    context.state_mut().echo_str("TODO: search");
+    Ok(())
+}
+
+fn handle_forward_search(context: &mut CommandHandlerContext) -> KeyResult {
+    handle_search(context, FocusDirection::Down)
+}
+
+fn handle_reverse_search(context: &mut CommandHandlerContext) -> KeyResult {
+    handle_search(context, FocusDirection::Up)
+}
+
+pub fn mappings() -> KeyTreeNode {
+    vim_tree! {
+        "/" => |ctx| {
+            ctx.state_mut().clear_echo();
+            ctx.state_mut().prompt.activate("/".into());
+
+            ctx.keymap.push_mode(VimPromptConfig{
+                prompt: "/".into(),
+                handler: Box::new(handle_forward_search),
+                completer: None,
+            }.into());
+
+            Ok(())
+        },
+
+        "?" => |ctx| {
+            ctx.state_mut().clear_echo();
+            ctx.state_mut().prompt.activate("?".into());
+
+            ctx.keymap.push_mode(VimPromptConfig{
+                prompt: "?".into(),
+                handler: Box::new(handle_reverse_search),
+                completer: None,
+            }.into());
+
+            Ok(())
+        },
+
+        "n" => |?mut _ctx| {
+            Err(KeyError::InvalidInput("Result browsing not yet supported".to_string()))
+        },
+
+        "N" => |?mut _ctx| {
+            Err(KeyError::InvalidInput("Result browsing not yet supported".to_string()))
+        },
+    }
+}

--- a/src/input/maps/vim/normal/search.rs
+++ b/src/input/maps/vim/normal/search.rs
@@ -35,6 +35,7 @@ fn handle_search(context: &mut CommandHandlerContext, ui: char, motion: SearchMo
         Ok(()) => {
             let end_cursor = context.state().current_window().cursor;
             if end_cursor == initial_cursor {
+                context.state_mut().clear_echo();
                 Err(KeyError::PatternNotFound(query))
             } else {
                 if end_cursor > initial_cursor && ui == '?' {

--- a/src/input/maps/vim/normal/search.rs
+++ b/src/input/maps/vim/normal/search.rs
@@ -157,20 +157,10 @@ fn next_search(ctx: KeyHandlerContext<VimKeymap>, match_direction: bool) -> KeyR
 
 pub fn mappings() -> KeyTreeNode {
     vim_tree! {
-        "/" => |?mut ctx| {
-            activate_search(ctx, '/', Box::new(handle_forward_search))
-        },
+        "/" => |?mut ctx| activate_search(ctx, '/', Box::new(handle_forward_search)),
+        "?" => |?mut ctx| activate_search(ctx, '?', Box::new(handle_backward_search)),
 
-        "?" => |?mut ctx| {
-            activate_search(ctx, '?', Box::new(handle_backward_search))
-        },
-
-        "n" => |?mut ctx| {
-            next_search(ctx, true)
-        },
-
-        "N" => |?mut ctx| {
-            next_search(ctx, false)
-        },
+        "n" => |?mut ctx| next_search(ctx, true),
+        "N" => |?mut ctx| next_search(ctx, false),
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -6,6 +6,7 @@ pub mod source;
 
 pub use source::KeySource;
 
+use std::any::Any;
 use std::io;
 use std::time::Duration;
 
@@ -167,6 +168,7 @@ pub trait Remappable<T: Keymap + BoxableKeymap>: BoxableKeymap {
 pub trait BoxableKeymap {
     fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
     fn remap_keys_user_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
+    fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
 impl BoxableKeymap for Box<&mut dyn BoxableKeymap> {
@@ -174,6 +176,7 @@ impl BoxableKeymap for Box<&mut dyn BoxableKeymap> {
         to (**self) {
             fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
             fn remap_keys_user_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
+            fn as_any_mut(&mut self) -> &mut dyn Any;
         }
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,5 +1,6 @@
 pub mod commands;
 pub mod completion;
+pub mod history;
 pub mod keys;
 pub mod maps;
 pub mod source;

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -69,6 +69,7 @@ pub enum KeyError {
     Interrupted,
     InvalidInput(String),
     NoSuchCommand(String),
+    PatternNotFound(String),
 }
 
 impl From<KeyError> for io::Error {


### PR DESCRIPTION
What this includes:

- `/` and `?` as proper motions
- `nN` to go to next/previous match

Left for future work:

- Repeat last search via `/<cr>`
- Pattern support (we currently just do a simple string match) - we should probably expose `search()` to scripting
- `gn` (needs visual mode)
- `incsearch` support (probably want to build general buffer highlights)

Closes #49 

Details:

- Scaffold out search support
- Add basic search motion + support executing it against operators
- Fix tests
- Prepare some search tests; fix infinite loop when not found
- Support search looping around the ends of the Buffer
- Prevent echo buffering when returning PatternNotFound error
- Cleanup/refactor code
- Support repeating the most recent search via n/N
- Sanity check empty search pattern
- Fix: giving up too early due to staying at the same unmatched char
