### PR TITLE
Add a simple splash screen

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -23,6 +23,7 @@ impl<T: UI> App<T> {
     pub fn render(&mut self) {
         let wanted_redraw = self.state.requested_redraw;
 
+        self.state.on_pre_draw();
         self.ui.render_app(&mut self.state);
         self.state.requested_redraw = false;
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -142,7 +142,7 @@ impl AppState {
         if self.showing_splash
             && (self.buffers.most_recent_id().unwrap_or(0) > FIRST_USER_BUFFER_ID
                 || self.tabpages.len() > 1
-                || self.current_tab().len() > 1
+                || self.current_tab().windows_count() > 1
                 || !self
                     .current_window()
                     .current_buffer(&self.buffers)

--- a/src/demo.rs
+++ b/src/demo.rs
@@ -14,6 +14,7 @@ pub fn perform_demo(app: &mut App<Tui>) {
     buffer.append(tui::text::Text::raw("Bacon ipsum dolor amet fatback hamburger capicola, andouille kielbasa prosciutto doner pork loin turducken kevin. Pork belly chislic leberkas ground round cow meatloaf beef. Landjaeger ground round ham chislic brisket buffalo pork loin meatloaf tail drumstick tongue spare ribs."));
 
     // make sure we have an initial measurement
+    app.state.request_redraw();
     app.render();
 
     let page = app.state.tabpages.current_tab_mut();

--- a/src/editing/buffers.rs
+++ b/src/editing/buffers.rs
@@ -58,6 +58,10 @@ impl Buffers {
         self.all.push(boxed);
     }
 
+    pub fn most_recent_id(&self) -> Option<Id> {
+        self.ids.most_recent()
+    }
+
     #[cfg(test)]
     pub fn replace(&mut self, buffer: Box<dyn Buffer>) -> Box<dyn Buffer> {
         let id = buffer.id();

--- a/src/editing/ids.rs
+++ b/src/editing/ids.rs
@@ -5,15 +5,27 @@ pub const FIRST_USER_BUFFER_ID: Id = 1;
 
 pub struct Ids {
     next: usize,
+    initial: usize,
 }
 
 impl Ids {
     pub fn new() -> Self {
-        Self { next: 0 }
+        Self::with_first(0)
     }
 
     pub fn with_first(next: Id) -> Self {
-        Self { next }
+        Self {
+            next,
+            initial: next,
+        }
+    }
+
+    pub fn most_recent(&self) -> Option<Id> {
+        if self.next <= self.initial {
+            None
+        } else {
+            Some(self.next - 1)
+        }
     }
 
     pub fn next(&mut self) -> Id {

--- a/src/editing/layout/conn.rs
+++ b/src/editing/layout/conn.rs
@@ -85,6 +85,10 @@ impl Layout for ConnLayout {
             h: self.output.size.h + self.input.size.h,
         }
     }
+
+    fn windows_count(&self) -> usize {
+        2
+    }
 }
 
 impl Resizable for ConnLayout {

--- a/src/editing/layout/linear.rs
+++ b/src/editing/layout/linear.rs
@@ -218,6 +218,10 @@ impl Layout for LinearLayout {
     fn into_splittable(&mut self) -> Option<Box<&mut dyn SplitableLayout>> {
         Some(Box::new(self))
     }
+
+    fn windows_count(&self) -> usize {
+        self.entries.iter().map(|entry| entry.windows_count()).sum()
+    }
 }
 
 impl SplitableLayout for LinearLayout {

--- a/src/editing/layout/mod.rs
+++ b/src/editing/layout/mod.rs
@@ -27,6 +27,7 @@ pub trait Layout: Renderable + Resizable {
     fn next_focus(&self, current_id: Id, direction: FocusDirection) -> Option<Id>;
     fn first_focus(&self, direction: FocusDirection) -> Option<Id>;
     fn size(&self) -> Size;
+    fn windows_count(&self) -> usize;
 
     fn by_id_for_split(&mut self, id: Id) -> Option<&mut Box<Window>> {
         self.by_id_mut(id)

--- a/src/editing/layout/win.rs
+++ b/src/editing/layout/win.rs
@@ -70,6 +70,10 @@ impl Layout for WinLayout {
     fn size(&self) -> Size {
         self.window.size
     }
+
+    fn windows_count(&self) -> usize {
+        1
+    }
 }
 
 impl Resizable for WinLayout {

--- a/src/editing/motion/char.rs
+++ b/src/editing/motion/char.rs
@@ -25,6 +25,10 @@ impl Motion for CharMotion {
     }
 
     fn destination<T: super::MotionContext>(&self, context: &T) -> CursorPosition {
+        if context.buffer().is_empty() {
+            return context.cursor();
+        }
+
         let from = context.cursor();
         match self {
             &CharMotion::Forward(step) => {

--- a/src/editing/tabpage.rs
+++ b/src/editing/tabpage.rs
@@ -73,8 +73,8 @@ impl Tabpage {
         self.layout.len() > 0
     }
 
-    pub fn len(&self) -> usize {
-        self.layout.len()
+    pub fn windows_count(&self) -> usize {
+        self.layout.windows_count()
     }
 
     pub fn windows_for_buffer(&mut self, buffer_id: Id) -> impl Iterator<Item = &mut Box<Window>> {

--- a/src/editing/tabpage.rs
+++ b/src/editing/tabpage.rs
@@ -73,6 +73,10 @@ impl Tabpage {
         self.layout.len() > 0
     }
 
+    pub fn len(&self) -> usize {
+        self.layout.len()
+    }
+
     pub fn windows_for_buffer(&mut self, buffer_id: Id) -> impl Iterator<Item = &mut Box<Window>> {
         self.layout.windows_for_buffer(buffer_id)
     }

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -72,11 +72,7 @@ fn mappings(config: VimPromptConfig) -> KeyTreeNode {
              ctx.state_mut().prompt.clear();
 
              // submit to handler
-             let result = (config.handler)(&mut CommandHandlerContext::new(&mut ctx.context, ctx.keymap, input));
-
-             ctx.state_mut().request_redraw();
-
-             result
+             (config.handler)(&mut CommandHandlerContext::new(&mut ctx.context, ctx.keymap, input))
          },
     }
 }

--- a/src/input/maps/vim/prompt.rs
+++ b/src/input/maps/vim/prompt.rs
@@ -72,7 +72,11 @@ fn mappings(config: VimPromptConfig) -> KeyTreeNode {
              ctx.state_mut().prompt.clear();
 
              // submit to handler
-             (config.handler)(&mut CommandHandlerContext::new(&mut ctx.context, ctx.keymap, input))
+             let result = (config.handler)(&mut CommandHandlerContext::new(&mut ctx.context, ctx.keymap, input));
+
+             ctx.state_mut().request_redraw();
+
+             result
          },
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -16,6 +16,7 @@ pub mod events;
 pub mod layout;
 pub mod measure;
 pub mod rendering;
+mod splash;
 pub mod tabpage;
 pub mod tabpages;
 pub mod window;
@@ -87,6 +88,10 @@ impl Tui {
                 },
                 &mut display,
             );
+        }
+
+        if app.showing_splash {
+            splash::render(&mut display);
         }
 
         self.render_display(display)

--- a/src/tui/splash.rs
+++ b/src/tui/splash.rs
@@ -1,4 +1,6 @@
+use clap::crate_version;
 use tui::layout::Rect;
+use tui::style::Modifier;
 use tui::widgets::Paragraph;
 use tui::widgets::Widget;
 use tui::{
@@ -11,20 +13,34 @@ use super::rendering::display::Display;
 use crate::editing::Size;
 
 pub fn render(display: &mut Display) {
-    let Size { w, h } = display.size;
+    let var_style = Style::default().add_modifier(Modifier::BOLD);
+    let enter_style = Style::default().fg(Color::Magenta);
 
-    let widget_height = 3;
-    let widget = Paragraph::new(vec![
+    // TODO Maybe we can simplify the alignment and formatting of these hints?
+    let lines = vec![
         Spans::from("iaido"),
+        Spans::from(format!("version {}", crate_version!())),
         Spans::from(""),
         Spans::from(vec![
-            Span::from("type  :q"),
-            Span::styled("<Enter>", Style::default().fg(Color::Magenta)),
-            Span::from("  to exit"),
+            Span::from("type  :connect "),
+            Span::styled("<host>", var_style),
+            Span::from(":"),
+            Span::styled("<port>", var_style),
+            Span::styled("<Enter>", enter_style),
+            Span::from("  to connect"),
         ]),
-    ])
-    .alignment(Alignment::Center);
+        Spans::from(vec![
+            Span::from("type  :q"),
+            Span::styled("<Enter>", enter_style),
+            Span::from("                      to exit   "),
+        ]),
+    ];
 
+    let widget_height = lines.len() as u16;
+    let widget = Paragraph::new(lines).alignment(Alignment::Center);
+
+    // Render vertically centered
+    let Size { w, h } = display.size;
     widget.render(
         Rect::new(0, h / 2 - widget_height / 2, w, widget_height),
         &mut display.buffer,

--- a/src/tui/splash.rs
+++ b/src/tui/splash.rs
@@ -19,7 +19,12 @@ pub fn render(display: &mut Display) {
     // TODO Maybe we can simplify the alignment and formatting of these hints?
     let lines = vec![
         Spans::from("iaido"),
-        Spans::from(format!("version {}", crate_version!())),
+        Spans::from(vec![
+            Span::from("version "),
+            Span::styled(crate_version!(), Style::default().fg(Color::LightMagenta)),
+        ]),
+        Spans::from(""),
+        Spans::from("https://github.com/dhleong/iaido"),
         Spans::from(""),
         Spans::from(vec![
             Span::from("type  :connect "),

--- a/src/tui/splash.rs
+++ b/src/tui/splash.rs
@@ -1,0 +1,32 @@
+use tui::layout::Rect;
+use tui::widgets::Paragraph;
+use tui::widgets::Widget;
+use tui::{
+    layout::Alignment,
+    style::{Color, Style},
+    text::{Span, Spans},
+};
+
+use super::rendering::display::Display;
+use crate::editing::Size;
+
+pub fn render(display: &mut Display) {
+    let Size { w, h } = display.size;
+
+    let widget_height = 3;
+    let widget = Paragraph::new(vec![
+        Spans::from("iaido"),
+        Spans::from(""),
+        Spans::from(vec![
+            Span::from("type  :q"),
+            Span::styled("<Enter>", Style::default().fg(Color::Magenta)),
+            Span::from("  to exit"),
+        ]),
+    ])
+    .alignment(Alignment::Center);
+
+    widget.render(
+        Rect::new(0, h / 2 - widget_height / 2, w, widget_height),
+        &mut display.buffer,
+    );
+}


### PR DESCRIPTION
Once we add a `:help` screen we can point users to there from the splash, which ought to be pretty helpful. The splash behaves like Vim's, where it stays around until the buffer gets editted, or a window is opened or something.

- Add a basic splash screen to provide some kind of intro
- Add version and a `:connect` hint to the splash
- Further tweak splash

![Screen Shot 2021-09-13 at 10 47 43 AM](https://user-images.githubusercontent.com/816150/133105486-bd9240f8-8e58-41dc-a795-0753c4c8a036.png)