### PR TITLE
Attempt to avoid double CI jobs on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
We currently have two "checks" for PRs, but it's the same task. Not a big deal, but might as well avoid wasting the CPU if possible
