### PR TITLE
Implement prompt history navigation

### DIFF
--- a/src/input/history.rs
+++ b/src/input/history.rs
@@ -2,6 +2,8 @@ use std::collections::vec_deque::Iter;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 
+use crate::app::prompt::Prompt;
+
 const DEFAULT_HISTORY_LIMIT: usize = 10000;
 
 pub struct History<T> {
@@ -18,7 +20,11 @@ impl<T> History<T> {
     }
 
     pub fn first(&self) -> Option<&T> {
-        self.items.get(0)
+        self.nth(0)
+    }
+
+    pub fn nth(&self, n: usize) -> Option<&T> {
+        self.items.get(n)
     }
 
     pub fn insert(&mut self, item: T) {
@@ -52,6 +58,16 @@ impl StringHistories {
             .or_insert_with(|| Default::default())
     }
 
+    pub fn take(&mut self, key: &String) -> History<String> {
+        self.histories
+            .remove(key)
+            .unwrap_or_else(|| Default::default())
+    }
+
+    pub fn replace(&mut self, key: String, history: History<String>) {
+        self.histories.insert(key, history);
+    }
+
     pub fn get_most_recent(&self, key: &str) -> Option<&String> {
         if let Some(history) = self.histories.get(key) {
             history.first()
@@ -70,6 +86,58 @@ impl StringHistories {
         }
 
         history.insert(entry)
+    }
+}
+
+#[derive(Default)]
+pub struct HistoryCursor {
+    index: Option<usize>,
+    stashed_input: Option<String>,
+}
+
+impl HistoryCursor {
+    pub fn back<'h, T>(
+        &mut self,
+        prompt: &Prompt,
+        prompt_len: usize,
+        history: &'h History<T>,
+    ) -> Option<&'h T> {
+        if let Some(previous_index) = self.index {
+            // TODO If stashed_input is not None, vim would search for a prefix match
+            let next_index = previous_index + 1;
+            if let Some(next) = history.iter().skip(next_index).next() {
+                self.index = Some(next_index);
+                Some(next)
+            } else {
+                None
+            }
+        } else if let Some(first_history) = history.nth(0) {
+            self.stashed_input = Some((&prompt.buffer.get_contents()[prompt_len..]).to_string());
+            self.index = Some(0);
+            Some(first_history)
+        } else {
+            None
+        }
+    }
+
+    pub fn forward<'h, T>(&mut self, history: &'h History<T>) -> Option<&'h T> {
+        if let Some(previous_index) = self.index {
+            // TODO If stashed_input is not None, vim would search for a prefix match
+            if previous_index > 0 {
+                let new_index = previous_index - 1;
+                self.index = Some(new_index);
+                history.nth(new_index)
+            } else {
+                self.index = None;
+                None
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn take_stashed_input(&mut self) -> Option<String> {
+        self.stashed_input.take()
     }
 }
 

--- a/src/input/history.rs
+++ b/src/input/history.rs
@@ -52,8 +52,8 @@ impl StringHistories {
             .or_insert_with(|| Default::default())
     }
 
-    pub fn get_most_recent(&self, key: String) -> Option<&String> {
-        if let Some(history) = self.histories.get(&key) {
+    pub fn get_most_recent(&self, key: &str) -> Option<&String> {
+        if let Some(history) = self.histories.get(key) {
             history.first()
         } else {
             None
@@ -61,6 +61,7 @@ impl StringHistories {
     }
 
     pub fn maybe_insert(&mut self, key: String, entry: String) {
+        // TODO This should actually *remove* older matching entries, per :help cmdline-history
         let history = self.get(key);
         if let Some(existing) = history.first() {
             if existing.to_owned() == entry {

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -50,6 +50,7 @@ fn cmd_mode_access() -> KeyTreeNode {
 
             ctx.keymap.push_mode(VimPromptConfig{
                 prompt: ":".into(),
+                history_key: ":".into(),
                 handler: Box::new(handle_command),
                 completer: Some(Rc::new(CommandsCompleter)),
             }.into());

--- a/src/input/maps/vim/normal/search.rs
+++ b/src/input/maps/vim/normal/search.rs
@@ -118,6 +118,7 @@ fn activate_search(
     ctx.keymap.push_mode(
         VimPromptConfig {
             prompt: ui.to_string(),
+            history_key: "/".to_string(),
             handler,
             completer: None,
         }
@@ -136,11 +137,7 @@ fn next_search(ctx: KeyHandlerContext<VimKeymap>, match_direction: bool) -> KeyR
         '?'
     };
 
-    if let Some(query_ref) = ctx
-        .keymap
-        .histories
-        .get_most_recent(SEARCH_HISTORY_KEY.to_string())
-    {
+    if let Some(query_ref) = ctx.keymap.histories.get_most_recent(SEARCH_HISTORY_KEY) {
         let query = query_ref.to_string();
         let initial_cursor = ctx.state().current_window().cursor;
         let motion = if ui == '/' {


### PR DESCRIPTION
This provides basic history recall/navigation (#66) for all "prompt"-based inputs---currently commands and search.

- Add *rough* initial (single-item!) history recall
- Implement step-wise history navigation!
- Make the HistoryCursor API more symmetrical
- Implement prefix-filtered history navigation
