### PR TITLE
Implement Command-line Window

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -132,6 +132,21 @@ impl AppState {
         }
     }
 
+    pub fn delete_buffer(&mut self, buffer_id: Id) {
+        if let Some(_) = self.buffers.remove(buffer_id) {
+            let window_ids: Vec<Id> = self
+                .tabpages
+                .windows_for_buffer(buffer_id)
+                .map(|win| win.id)
+                .collect();
+            for id in window_ids {
+                if let Some(tab) = self.tabpages.containing_window_mut(id) {
+                    tab.close_window(id);
+                }
+            }
+        }
+    }
+
     // ======= redraw =========================================
 
     pub fn request_redraw(&mut self) {

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Mutex};
 use crate::{
     connection::connections::Connections,
     editing::{
-        buffer::{CopiedRange, MemoryBuffer},
+        buffer::{BufHidden, CopiedRange, MemoryBuffer},
         buffers::Buffers,
         ids::FIRST_USER_BUFFER_ID,
         motion::char::CharMotion,
@@ -132,6 +132,36 @@ impl AppState {
         }
     }
 
+    pub fn close_window(&mut self, window_id: Id) {
+        let buffer_id = if let Some(tab) = self.tabpages.containing_window_mut(window_id) {
+            let buffer_id = if let Some(window) = tab.by_id(window_id) {
+                Some(window.buffer)
+            } else {
+                None
+            };
+
+            tab.close_window(window_id);
+
+            buffer_id
+        } else {
+            None
+        };
+
+        if let Some(buffer_id) = buffer_id {
+            if self.tabpages.windows_for_buffer(buffer_id).count() == 0 {
+                // No more windows; perform bufhidden (if the buffer still exists)
+                if let Some(buffer) = self.buffers.by_id(buffer_id) {
+                    match buffer.config().bufhidden {
+                        BufHidden::Delete => {
+                            self.buffers.remove(buffer_id);
+                        }
+                        _ => {} // nop
+                    };
+                }
+            }
+        }
+    }
+
     pub fn delete_buffer(&mut self, buffer_id: Id) {
         if let Some(_) = self.buffers.remove(buffer_id) {
             let window_ids: Vec<Id> = self
@@ -140,9 +170,7 @@ impl AppState {
                 .map(|win| win.id)
                 .collect();
             for id in window_ids {
-                if let Some(tab) = self.tabpages.containing_window_mut(id) {
-                    tab.close_window(id);
-                }
+                self.close_window(id);
             }
         }
     }

--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -6,11 +6,12 @@ use crate::editing::{
     Buffer, CursorPosition, HasId,
 };
 
-use super::{util::motion_to_line_ranges, CopiedRange};
+use super::{util::motion_to_line_ranges, BufferConfig, CopiedRange};
 
 pub struct MemoryBuffer {
     id: usize,
     content: TextLines,
+    config: BufferConfig,
     pub source: BufferSource,
 }
 
@@ -18,6 +19,7 @@ impl MemoryBuffer {
     pub fn new(id: usize) -> MemoryBuffer {
         MemoryBuffer {
             id,
+            config: BufferConfig::default(),
             content: TextLines::default(),
             source: BufferSource::None,
         }
@@ -31,6 +33,14 @@ impl HasId for MemoryBuffer {
 }
 
 impl Buffer for MemoryBuffer {
+    fn config(&self) -> &BufferConfig {
+        &self.config
+    }
+
+    fn config_mut(&mut self) -> &mut BufferConfig {
+        &mut self.config
+    }
+
     fn source(&self) -> &BufferSource {
         &self.source
     }
@@ -210,6 +220,7 @@ pub mod tests {
         fn assert_visual_match(&self, s: &'static str) {
             let expected = MemoryBuffer {
                 id: 0,
+                config: BufferConfig::default(),
                 content: s.into(),
                 source: BufferSource::None,
             }

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -221,12 +221,7 @@ pub trait Buffer: HasId + Send + Sync {
     }
 
     fn is_read_only(&self) -> bool {
-        match self.source() {
-            BufferSource::Connection(_) => true,
-            BufferSource::Help => true,
-            BufferSource::Log => true,
-            _ => false,
-        }
+        self.source().is_read_only()
     }
 
     fn get_char(&self, pos: CursorPosition) -> Option<&str> {

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -110,7 +110,26 @@ impl CopiedRange {
     }
 }
 
+pub enum BufHidden {
+    Hide,
+    Delete,
+}
+
+impl Default for BufHidden {
+    fn default() -> Self {
+        BufHidden::Hide
+    }
+}
+
+#[derive(Default)]
+pub struct BufferConfig {
+    pub bufhidden: BufHidden,
+}
+
 pub trait Buffer: HasId + Send + Sync {
+    fn config(&self) -> &BufferConfig;
+    fn config_mut(&mut self) -> &mut BufferConfig;
+
     // read access
     fn lines_count(&self) -> usize;
     fn get(&self, line_index: usize) -> &TextLine;

--- a/src/editing/buffer/undoable.rs
+++ b/src/editing/buffer/undoable.rs
@@ -50,6 +50,8 @@ impl HasId for UndoableBuffer {
 impl Buffer for UndoableBuffer {
     delegate! {
         to self.base {
+            fn config(&self) -> &crate::editing::buffer::BufferConfig;
+            fn config_mut(&mut self) -> &mut crate::editing::buffer::BufferConfig;
             fn source(&self) -> &crate::editing::source::BufferSource;
             fn set_source(&mut self, source: crate::editing::source::BufferSource);
             fn get(&self, line_index: usize) -> &crate::editing::text::TextLine;

--- a/src/editing/buffers.rs
+++ b/src/editing/buffers.rs
@@ -62,6 +62,14 @@ impl Buffers {
         self.ids.most_recent()
     }
 
+    pub fn remove(&mut self, id: Id) -> Option<Box<dyn Buffer>> {
+        if let Some(index) = self.all.iter_mut().position(|buf| buf.id() == id) {
+            Some(self.all.remove(index))
+        } else {
+            None
+        }
+    }
+
     #[cfg(test)]
     pub fn replace(&mut self, buffer: Box<dyn Buffer>) -> Box<dyn Buffer> {
         let id = buffer.id();

--- a/src/editing/gutter.rs
+++ b/src/editing/gutter.rs
@@ -1,0 +1,6 @@
+use crate::editing::text::TextLine;
+
+pub struct Gutter {
+    pub width: u8,
+    pub get_content: Box<dyn Fn(usize) -> TextLine>,
+}

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -1,6 +1,7 @@
 pub mod buffer;
 pub mod buffers;
 pub mod change;
+pub mod gutter;
 pub mod ids;
 pub mod layout;
 pub mod motion;

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -227,6 +227,16 @@ pub mod tests {
             todo!()
         }
 
+        fn buf_remap_keys_user_fn(
+            &mut self,
+            _id: crate::editing::Id,
+            _mode: crate::input::RemapMode,
+            _keys: Vec<crate::input::Key>,
+            _handler: Box<crate::input::maps::UserKeyHandler>,
+        ) {
+            todo!()
+        }
+
         fn remap_keys_user_fn(
             &mut self,
             _mode: crate::input::RemapMode,

--- a/src/editing/source/mod.rs
+++ b/src/editing/source/mod.rs
@@ -4,6 +4,7 @@ use super::Id;
 pub enum BufferSource {
     /// The Buffer is in-memory only
     None,
+    Cmdline,
 
     Help,
     Log,
@@ -25,6 +26,16 @@ impl BufferSource {
     pub fn is_none(&self) -> bool {
         match self {
             &BufferSource::None => true,
+            _ => false,
+        }
+    }
+
+    pub fn is_read_only(&self) -> bool {
+        match self {
+            BufferSource::Connection(_) => true,
+            BufferSource::Help => true,
+            BufferSource::Log => true,
+
             _ => false,
         }
     }

--- a/src/editing/window.rs
+++ b/src/editing/window.rs
@@ -2,6 +2,7 @@ use bitflags::bitflags;
 
 use std::cmp::{max, min};
 
+use crate::editing::gutter::Gutter;
 use crate::{
     input::completion::{state::CompletionState, Completion},
     tui::measure::Measurable,
@@ -28,6 +29,7 @@ pub struct Window {
     pub focused: bool,
     pub inserting: bool,
     pub flags: WindowFlags,
+    pub gutter: Option<Gutter>,
 
     pub cursor: CursorPosition,
 
@@ -51,6 +53,7 @@ impl Window {
             size: Size { w: 0, h: 0 },
             focused,
             flags: WindowFlags::NONE,
+            gutter: None,
             inserting: false,
             cursor: CursorPosition { line: 0, col: 0 },
             scrolled_lines: 0,

--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -28,7 +28,7 @@ fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyRes
 
     let connection_buffer_id = context.state().current_buffer().connection_buffer_id();
     let win_id = context.state().current_window().id;
-    context.state_mut().current_tab_mut().close_window(win_id);
+    context.state_mut().close_window(win_id);
 
     if let Some(id) = connection_buffer_id {
         // make sure we disconnect if there are no more windows

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -157,15 +157,15 @@ impl VimKeymap {
         config: KeymapConfig,
         mode: &RemapMode,
     ) -> Option<KeyTreeNode> {
+        if !config.allow_remap {
+            return None;
+        }
+
         let user_maps = self.user_maps.get(&mode);
         let buffer_maps = self
             .buffer_maps
             .get(&buf_id)
             .and_then(|maps| maps.get(&mode));
-
-        if !config.allow_remap {
-            return buffer_maps.and_then(|maps| Some(maps.clone()));
-        }
 
         match (user_maps, buffer_maps) {
             (None, None) => None,

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -51,15 +51,8 @@ fn open_cmdline_mode(mut ctx: KeyHandlerContext<VimKeymap>, history_key: String)
     let win_id = ctx.state_mut().current_tab_mut().split_bottom();
     let history = ctx.keymap.histories.take(&history_key);
 
-    let gutter_prefix = vec![Span::styled(
-        history_key.to_string(),
-        Style::default().fg(Color::DarkGray),
-    )];
-
     let buffer = ctx.state_mut().buffers.create_mut();
     let buf_id = buffer.id();
-
-    // TODO Resize to cmdwinheight
 
     let mut count = 0;
     for entry in history.iter().rev() {
@@ -68,9 +61,18 @@ fn open_cmdline_mode(mut ctx: KeyHandlerContext<VimKeymap>, history_key: String)
     }
 
     ctx.state_mut().set_current_window_buffer(buf_id);
-    ctx.keymap.histories.replace(history_key, history);
+    ctx.keymap
+        .histories
+        .replace(history_key.to_string(), history);
 
     let win = ctx.state_mut().current_tab_mut().by_id_mut(win_id).unwrap();
+
+    // TODO Resize to cmdwinheight
+
+    let gutter_prefix = vec![Span::styled(
+        history_key,
+        Style::default().fg(Color::DarkGray),
+    )];
 
     win.gutter = Some(Gutter {
         width: 1,

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -59,13 +59,15 @@ fn submit_cmdline(mut ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> 
         let win_id = ctx.state().current_window().id;
         ctx.state_mut().current_tab_mut().close_window(win_id);
 
-        ctx = ctx.feed_keys(prompt_key.into_keys())?;
-
         // Is this *too* hacky? Just feed each char as a key:
-        let cmd_as_keys: Vec<Key> = cmd.chars().map(|ch| Key::from(KeyCode::Char(ch))).collect();
-        ctx = ctx.feed_keys(cmd_as_keys)?;
+        // Perhaps we should match on prompt_key and invoke eg `handle_command`,
+        // `handle_forward_search`, etc. directly...
+        ctx = ctx.feed_keys_noremap(prompt_key.into_keys())?;
 
-        ctx.feed_keys("<cr>".into_keys())?;
+        let cmd_as_keys: Vec<Key> = cmd.chars().map(|ch| Key::from(KeyCode::Char(ch))).collect();
+        ctx = ctx.feed_keys_noremap(cmd_as_keys)?;
+
+        ctx.feed_keys_noremap("<cr>".into_keys())?;
     }
     Ok(())
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -8,7 +8,6 @@ use std::rc::Rc;
 use tui::style::{Color, Style};
 use tui::text::{Span, Spans};
 
-use crate::editing::text::EditableLine;
 use crate::input::{
     commands::CommandHandlerContext,
     completion::commands::CommandsCompleter,
@@ -18,12 +17,13 @@ use crate::input::{
 };
 use crate::input::{Key, KeyCode};
 use crate::{
+    editing::buffer::BufHidden,
     editing::gutter::Gutter,
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
     editing::motion::{Motion, MotionFlags, MotionRange},
     editing::source::BufferSource,
-    editing::text::TextLine,
+    editing::text::{EditableLine, TextLine},
 };
 use crate::{key_handler, vim_tree};
 
@@ -86,6 +86,7 @@ fn open_cmdline_mode(
     let buffer = ctx.state_mut().buffers.create_mut();
     let buf_id = buffer.id();
     buffer.set_source(BufferSource::Cmdline);
+    buffer.config_mut().bufhidden = BufHidden::Delete;
 
     let mut count = 0;
     for entry in history.iter().rev() {

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -49,28 +49,42 @@ fn handle_command(mut context: &mut CommandHandlerContext) -> KeyResult {
     }
 }
 
-fn submit_cmdline(mut ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
-    if let Some(cmd_spans) = ctx
+fn cmdline_to_prompt(
+    mut ctx: KeyHandlerContext<VimKeymap>,
+    prompt_key: String,
+) -> KeyResult<KeyHandlerContext<VimKeymap>> {
+    let cmd = if let Some(cmd_spans) = ctx
         .state()
         .current_buffer()
         .checked_get(ctx.state().current_window().cursor.line)
     {
-        let cmd = cmd_spans.to_string();
+        cmd_spans.to_string()
+    } else {
+        "".to_string()
+    };
 
-        // Release the buffer
-        let buffer_id = ctx.state().current_buffer().id();
-        ctx.state_mut().delete_buffer(buffer_id);
+    // Release the buffer
+    let buffer_id = ctx.state().current_buffer().id();
+    ctx.state_mut().delete_buffer(buffer_id);
 
-        // Is this *too* hacky? Just feed each char as a key:
-        // Perhaps we should match on prompt_key and invoke eg `handle_command`,
-        // `handle_forward_search`, etc. directly...
-        ctx = ctx.feed_keys_noremap(prompt_key.into_keys())?;
+    // Is this *too* hacky? Just feed each char as a key:
+    // Perhaps we should match on prompt_key and invoke eg `handle_command`,
+    // `handle_forward_search`, etc. directly...
+    ctx = ctx.feed_keys_noremap(prompt_key.into_keys())?;
 
-        let cmd_as_keys: Vec<Key> = cmd.chars().map(|ch| Key::from(KeyCode::Char(ch))).collect();
-        ctx = ctx.feed_keys_noremap(cmd_as_keys)?;
+    let cmd_as_keys: Vec<Key> = cmd.chars().map(|ch| Key::from(KeyCode::Char(ch))).collect();
+    ctx = ctx.feed_keys_noremap(cmd_as_keys)?;
+    Ok(ctx)
+}
 
-        ctx.feed_keys_noremap("<cr>".into_keys())?;
-    }
+fn cancel_cmdline(ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
+    cmdline_to_prompt(ctx, prompt_key)?;
+    Ok(())
+}
+
+fn submit_cmdline(ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
+    let ctx = cmdline_to_prompt(ctx, prompt_key)?;
+    ctx.feed_keys_noremap("<cr>".into_keys())?;
     Ok(())
 }
 
@@ -101,6 +115,7 @@ fn open_cmdline_mode(
 
     // Bind <cr> to submit the input
     let normal_prompt_key = prompt_key.clone();
+    let insert_prompt_key = prompt_key.clone();
     ctx.keymap.buf_remap_keys_fn(
         buf_id,
         RemapMode::VimNormal,
@@ -111,7 +126,22 @@ fn open_cmdline_mode(
         buf_id,
         RemapMode::VimInsert,
         "<cr>".into_keys(),
-        Box::new(move |ctx| submit_cmdline(ctx, prompt_key.to_string())),
+        Box::new(move |ctx| submit_cmdline(ctx, insert_prompt_key.to_string())),
+    );
+
+    // Bind <ctrl-c> to cancel the mode
+    let normal_prompt_key = prompt_key.clone();
+    ctx.keymap.buf_remap_keys_fn(
+        buf_id,
+        RemapMode::VimNormal,
+        "<ctrl-c>".into_keys(),
+        Box::new(move |ctx| cancel_cmdline(ctx, normal_prompt_key.to_string())),
+    );
+    ctx.keymap.buf_remap_keys_fn(
+        buf_id,
+        RemapMode::VimInsert,
+        "<ctrl-c>".into_keys(),
+        Box::new(move |ctx| cancel_cmdline(ctx, prompt_key.to_string())),
     );
 
     let win = ctx.state_mut().current_tab_mut().by_id_mut(win_id).unwrap();

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -56,8 +56,10 @@ fn submit_cmdline(mut ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> 
         .checked_get(ctx.state().current_window().cursor.line)
     {
         let cmd = cmd_spans.to_string();
-        let win_id = ctx.state().current_window().id;
-        ctx.state_mut().current_tab_mut().close_window(win_id);
+
+        // Release the buffer
+        let buffer_id = ctx.state().current_buffer().id();
+        ctx.state_mut().delete_buffer(buffer_id);
 
         // Is this *too* hacky? Just feed each char as a key:
         // Perhaps we should match on prompt_key and invoke eg `handle_command`,

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -99,6 +99,10 @@ fn cmd_mode_access() -> KeyTreeNode {
         "q:" => |?mut ctx| {
             open_cmdline_mode(ctx, ":".to_string())
         },
+
+        "q/" => |?mut ctx| {
+            open_cmdline_mode(ctx, "/".to_string())
+        },
     }
 }
 

--- a/src/input/maps/vim/normal/window.rs
+++ b/src/input/maps/vim/normal/window.rs
@@ -1,8 +1,8 @@
 use crate::input::maps::vim::VimKeymap;
 use crate::input::maps::{vim::tree::KeyTreeNode, KeyHandlerContext};
-use crate::input::KeymapContext;
+use crate::input::{KeyError, KeymapContext};
 use crate::vim_tree;
-use crate::{editing::FocusDirection, input::maps::KeyResult};
+use crate::{editing::source::BufferSource, editing::FocusDirection, input::maps::KeyResult};
 
 pub fn mappings() -> KeyTreeNode {
     vim_tree! {
@@ -24,6 +24,13 @@ pub fn mappings() -> KeyTreeNode {
 }
 
 fn focus(mut ctx: KeyHandlerContext<VimKeymap>, direction: FocusDirection) -> KeyResult {
-    ctx.state_mut().current_tab_mut().move_focus(direction);
-    Ok(())
+    match ctx.state().current_buffer().source() {
+        &BufferSource::Cmdline => Err(KeyError::NotPermitted(
+            "Invalid in command-line window; <CR> executes, CTRL-C quits".to_string(),
+        )),
+        _ => {
+            ctx.state_mut().current_tab_mut().move_focus(direction);
+            Ok(())
+        }
+    }
 }

--- a/src/input/maps/vim/tree.rs
+++ b/src/input/maps/vim/tree.rs
@@ -44,34 +44,42 @@ impl KeyTreeNode {
     }
 }
 
-impl ops::Add<KeyTreeNode> for KeyTreeNode {
+impl ops::Add<&KeyTreeNode> for &KeyTreeNode {
     type Output = KeyTreeNode;
 
-    fn add(self, mut rhs: KeyTreeNode) -> Self::Output {
+    fn add(self, rhs: &KeyTreeNode) -> Self::Output {
         let mut result = KeyTreeNode::root();
 
-        if let Some(rhs_handler) = rhs.handler {
-            result.handler = Some(rhs_handler);
+        if let Some(rhs_handler) = &rhs.handler {
+            result.handler = Some(rhs_handler.clone());
         } else {
-            result.handler = self.handler;
+            result.handler = self.handler.clone();
         }
 
         // combine shared child nodes and insert our unmatched nodes
-        for (key, child) in self.children {
-            if let Some(rhs_child) = rhs.children.remove(&key) {
-                result.children.insert(key, child + rhs_child);
+        for (key, child) in &self.children {
+            if let Some(rhs_child) = rhs.children.get(&key) {
+                result.children.insert(key.clone(), child + rhs_child);
             } else {
-                result.children.insert(key, child);
+                result.children.insert(key.clone(), child.clone());
             }
         }
 
         // insert their unmatched nodes
-        for (key, child) in rhs.children {
+        for (key, child) in &rhs.children {
             if !result.children.contains_key(&key) {
-                result.children.insert(key, child);
+                result.children.insert(key.clone(), child.clone());
             }
         }
 
         result
+    }
+}
+
+impl ops::Add<KeyTreeNode> for KeyTreeNode {
+    type Output = KeyTreeNode;
+
+    fn add(self, rhs: KeyTreeNode) -> Self::Output {
+        &self + &rhs
     }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -92,7 +92,21 @@ impl From<url::ParseError> for KeyError {
     }
 }
 
+#[derive(PartialEq, Clone, Copy)]
+pub struct KeymapConfig {
+    pub allow_remap: bool,
+}
+
+impl Default for KeymapConfig {
+    fn default() -> Self {
+        Self { allow_remap: true }
+    }
+}
+
 pub trait KeymapContext: KeySource {
+    fn config(&self) -> KeymapConfig {
+        KeymapConfig::default()
+    }
     fn state(&self) -> &crate::app::State;
     fn state_mut(&mut self) -> &mut crate::app::State;
 }
@@ -119,12 +133,13 @@ impl KeySource for Box<&mut dyn KeymapContext> {
 
 pub struct KeymapContextWithKeys<'a, K: KeySource> {
     base: Box<&'a mut dyn KeymapContext>,
+    pub config: KeymapConfig,
     keys: K,
 }
 
 impl<'a, K: KeySource> KeymapContextWithKeys<'a, K> {
-    pub fn new(base: Box<&'a mut dyn KeymapContext>, keys: K) -> Self {
-        Self { base, keys }
+    pub fn new(base: Box<&'a mut dyn KeymapContext>, keys: K, config: KeymapConfig) -> Self {
+        Self { base, keys, config }
     }
 }
 
@@ -134,6 +149,9 @@ impl<'a, K: KeySource> KeymapContext for KeymapContextWithKeys<'a, K> {
             fn state(&self) -> &crate::app::State;
             fn state_mut(&mut self) -> &mut crate::app::State;
         }
+    }
+    fn config(&self) -> KeymapConfig {
+        self.config
     }
 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -11,6 +11,7 @@ use std::any::Any;
 use std::io;
 use std::time::Duration;
 
+use crate::editing::Id;
 use crate::{app::jobs::JobError, delegate_keysource};
 use delegate::delegate;
 
@@ -165,11 +166,25 @@ pub fn remap_keys_to_fn<K: Keymap + BoxableKeymap, R: Remappable<K>>(
 
 pub trait Remappable<T: Keymap + BoxableKeymap>: BoxableKeymap {
     fn remap_keys_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<KeyHandler<T>>);
+    fn buf_remap_keys_fn(
+        &mut self,
+        buf_id: Id,
+        mode: RemapMode,
+        keys: Vec<Key>,
+        handler: Box<KeyHandler<T>>,
+    );
 }
 
 pub trait BoxableKeymap {
     fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
     fn remap_keys_user_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
+    fn buf_remap_keys_user_fn(
+        &mut self,
+        buf_id: Id,
+        mode: RemapMode,
+        keys: Vec<Key>,
+        handler: Box<UserKeyHandler>,
+    );
     fn as_any_mut(&mut self) -> &mut dyn Any;
 }
 
@@ -178,6 +193,7 @@ impl BoxableKeymap for Box<&mut dyn BoxableKeymap> {
         to (**self) {
             fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
             fn remap_keys_user_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
+            fn buf_remap_keys_user_fn(&mut self, buf_id: Id, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
             fn as_any_mut(&mut self) -> &mut dyn Any;
         }
     }

--- a/src/script/api/window.rs
+++ b/src/script/api/window.rs
@@ -39,9 +39,7 @@ impl WindowApiObject {
 
     #[rpc(passing(self.id))]
     pub fn close(context: &mut CommandHandlerContext, id: Id) {
-        if let Some(tab) = context.state_mut().tabpages.containing_window_mut(id) {
-            tab.close_window(id);
-        }
+        context.state_mut().close_window(id);
     }
 }
 


### PR DESCRIPTION
Along the way, we ended up implementing a couple other things:

- "noremap" `feed_keys` mode
- `bufhidden` option for buffers (only hard-coded for now, and only `delete` or `hide`

Still probably TODO:

- [x] Prevent leaving cmdline window in the normal way

Closes #66 

- Add initial support for generating a cmdline window
- Add the cmdline window "gutter"
- Add q/ mapping
- Group window manipulation together
- Support buffer-specific mappings in prep for submitting cmdline input
- Support submitting commands by feeding them as keys
- Support feeding keys while ignoring user remaps
- Ignore *all* custom maps when allow_remap is `false`
- Delete the cmdline window buffer on execute
- Add (non-functional) bufhidden flag for buffers
- Implement BufHidden::Delete setting to ensure cmdline is cleaned up

<img width="682" alt="Screen Shot 2021-11-28 at 10 08 06 AM" src="https://user-images.githubusercontent.com/816150/143773718-92b9a351-e3ea-45ec-bf28-898273245e47.png">

