### PR TITLE
Fix: off-by-one error placing the cursor in an empty window

### DIFF
--- a/src/tui/window.rs
+++ b/src/tui/window.rs
@@ -242,7 +242,7 @@ impl Renderable for Window {
                 (x, y)
             } else {
                 // simple case
-                (area.x, area.y)
+                (area.x, area.y.checked_sub(1).unwrap_or(0))
             };
 
             if self.inserting {


### PR DESCRIPTION
This fixes the issue where the cursor will appear to be in the prompt
line on first start, but entering insert mode and typing will place the
content where it's meant to be and then relocate the cursor
appropriately as well.
