### PR TITLE
Improve cmdline window gutter rendering

### DIFF
--- a/src/editing/gutter.rs
+++ b/src/editing/gutter.rs
@@ -2,5 +2,5 @@ use crate::editing::text::TextLine;
 
 pub struct Gutter {
     pub width: u8,
-    pub get_content: Box<dyn Fn(usize) -> TextLine>,
+    pub get_content: Box<dyn Fn(Option<usize>) -> TextLine>,
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -148,6 +148,8 @@ fn open_cmdline_mode(
 
     // TODO Resize to cmdwinheight
 
+    let non_line_prefix = vec![Span::styled("~", Style::default().fg(Color::DarkGray))];
+
     let gutter_prefix = vec![Span::styled(
         history_key,
         Style::default().fg(Color::DarkGray),
@@ -155,7 +157,12 @@ fn open_cmdline_mode(
 
     win.gutter = Some(Gutter {
         width: 1,
-        get_content: Box::new(move |_line| Spans(gutter_prefix.clone())),
+        get_content: Box::new(move |line| {
+            Spans(match line {
+                Some(_) => gutter_prefix.clone(),
+                None => non_line_prefix.clone(),
+            })
+        }),
     });
     win.cursor = (count, 0).into();
 


### PR DESCRIPTION
- Prevent rendering empty buffers as 0-height windows
- Render ~ in gutter of non-existent cmdline window lines

<img width="682" alt="Screen Shot 2021-11-28 at 4 04 19 PM" src="https://user-images.githubusercontent.com/816150/143785910-436f8562-89df-41d9-b2cd-54b5078dfddc.png">

