### PR TITLE
Fix various panics from manipulating empty buffers

### DIFF
--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -79,7 +79,7 @@ impl Buffer for MemoryBuffer {
                 if i == last_line_index {
                     copy.trailing_newline = true;
                 }
-            } else {
+            } else if self.has_line(line_index) {
                 // yank within the line
                 let (start, end) = range.resolve(line_index, self);
                 let line = &self.content.lines[line_index];
@@ -108,7 +108,7 @@ impl Buffer for MemoryBuffer {
                 if i == last_line_index {
                     copy.trailing_newline = true;
                 }
-            } else {
+            } else if self.has_line(line_index) {
                 // delete within the line
                 let (start, end) = range.resolve(line_index, self);
                 let line = &self.content.lines[line_index];

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -208,8 +208,12 @@ pub trait Buffer: HasId + Send + Sync {
         };
     }
 
+    fn has_line(&self, line_index: usize) -> bool {
+        !self.is_empty() && line_index < self.lines_count()
+    }
+
     fn checked_get(&self, line_index: usize) -> Option<&TextLine> {
-        if !self.is_empty() && line_index < self.lines_count() {
+        if self.has_line(line_index) {
             Some(self.get(line_index))
         } else {
             None

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -45,10 +45,14 @@ impl CursorPosition {
     }
 
     pub fn end_of_line(&self, buffer: &Box<dyn Buffer>) -> CursorPosition {
-        let line_width = buffer.get(self.line).width();
+        let col = if let Some(line) = buffer.checked_get(self.line) {
+            line.width()
+        } else {
+            0
+        };
         CursorPosition {
             line: self.line,
-            col: line_width,
+            col,
         }
     }
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -359,6 +359,13 @@ mod tests {
         use super::*;
 
         #[test]
+        fn d_in_empty() {
+            // Sanity check:
+            let ctx = window("");
+            ctx.feed_vim("dw").assert_visual_match("");
+        }
+
+        #[test]
         fn dd() {
             let ctx = window(indoc! {"
                 Take my love

--- a/src/input/maps/vim/normal/registers.rs
+++ b/src/input/maps/vim/normal/registers.rs
@@ -122,6 +122,13 @@ mod tests {
         use super::*;
 
         #[test]
+        fn yank_in_empty() {
+            // Sanity check:
+            let ctx = window("");
+            ctx.feed_vim("yw").assert_visual_match("");
+        }
+
+        #[test]
         fn yank_into_register() {
             let ctx = window("Take my |love");
             let (_, mut state) = ctx.feed_vim_for_state("\"ayw");


### PR DESCRIPTION
We should probably get rid of `Buffer.get()` entirely in favor of checked_get
