### PR TITLE
Automatically clamp window cursor to handle buffer changes

### DIFF
--- a/src/editing/buffer/memory.rs
+++ b/src/editing/buffer/memory.rs
@@ -139,6 +139,8 @@ impl Buffer for MemoryBuffer {
         if cursor == (0, 0).into() && self.content.lines.is_empty() {
             self.content.lines.push(text);
             return;
+        } else if self.content.lines.is_empty() {
+            panic!("insert at {:?} but empty", cursor);
         }
 
         let original = &self.content.lines[cursor.line];

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -140,6 +140,7 @@ mod tests {
     #[test]
     fn apply_next() {
         let mut win = window("take my |");
+        win.set_inserting(true);
         win.assert_visual_match("take my |");
 
         let mut state = completion_state(&mut win);
@@ -160,6 +161,7 @@ mod tests {
     #[test]
     fn apply_prev_and_next() {
         let mut win = window("take my |");
+        win.set_inserting(true);
         let mut state = completion_state(&mut win);
         state.apply_next(&mut win);
         state.apply_next(&mut win);

--- a/src/tui/rendering/display.rs
+++ b/src/tui/rendering/display.rs
@@ -90,7 +90,7 @@ pub mod tests {
 
     pub trait TestableDisplay {
         fn of_string(s: &'static str) -> Display;
-        fn of_sized_string<S: Into<Size>>(size: S, s: &'static str) -> Display;
+        fn of_sized_string<S: Into<Size>>(size: S, s: &'static str, inserting: bool) -> Display;
         fn cursor_coords(&self) -> Option<(u16, u16)>;
         fn to_visual_string(&self) -> String;
         fn assert_visual_match(&self, s: &'static str);
@@ -112,12 +112,16 @@ pub mod tests {
                     h: height as u16,
                 },
                 s,
+                false,
             );
         }
 
-        fn of_sized_string<S: Into<Size>>(size: S, s: &'static str) -> Display {
+        fn of_sized_string<S: Into<Size>>(size: S, s: &'static str, inserting: bool) -> Display {
             let mut display = Display::new(size.into());
             let mut win = window(s);
+            if inserting {
+                win.set_inserting(true);
+            }
             win.render(&mut display);
 
             display
@@ -157,7 +161,14 @@ pub mod tests {
         }
 
         fn assert_visual_match(&self, s: &'static str) {
-            let expected_display = Display::of_sized_string(self.size, s);
+            let expected_display = Display::of_sized_string(
+                self.size,
+                s,
+                match self.cursor {
+                    editing::Cursor::Line(_, _) => true,
+                    _ => false,
+                },
+            );
             assert_eq!(self.size, expected_display.size);
             assert_eq!(self.to_visual_string(), expected_display.to_visual_string());
         }


### PR DESCRIPTION
Fixes a panic when typing after sending input to a connection, due to
the cursor staying where it was after the buffer is cleared.

This change includes some fixes to tests so the "inserting" state of the
visual match window matches that of the source window, plus explicitly
setting "inserting" state in some tests where appropriate