### PR TITLE
Clean up and simplify backtraces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ mod ui;
 
 pub mod log;
 
+use crate::ui::backtrace::PanicData;
 use app::looper::app_loop;
 use backtrace::Backtrace;
 use input::maps::vim::VimKeymap;
@@ -41,11 +42,6 @@ fn main_loop() -> io::Result<()> {
     Ok(())
 }
 
-struct PanicData {
-    info: String,
-    trace: Backtrace,
-}
-
 fn main() -> io::Result<()> {
     // Prepare to capture any panics
     let panic_data = prepare_panic_capture();
@@ -74,7 +70,7 @@ fn main() -> io::Result<()> {
             let lock = panic_data.lock().unwrap();
             if let Some(ref data) = *lock {
                 println!("PANIC! {:?}", data.info);
-                println!("Backtrace:\n {:?}", data.trace);
+                println!("Backtrace:\n {}", data);
             } else {
                 println!("PANIC! {:?}", panic);
                 println!("(backtrace unavailable)");

--- a/src/ui/backtrace.rs
+++ b/src/ui/backtrace.rs
@@ -1,0 +1,74 @@
+use backtrace::{Backtrace, BacktraceFmt, BacktraceFrame, PrintFmt};
+use std::fmt::{self, Formatter};
+
+const ABBRIATABLE_FRAME_PREFIXES: &[&'static str] = &[
+    "backtrace::",
+    "std::sys_common::backtrace::",
+    "iaido::prepare_panic_capture",
+    "std::panicking",
+    "core::panicking",
+    "rust_begin_unwind",
+];
+
+pub struct PanicData {
+    pub info: String,
+    pub trace: Backtrace,
+}
+
+impl std::fmt::Display for PanicData {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), std::fmt::Error> {
+        let mut print_path =
+            move |fmt: &mut Formatter<'_>, path: backtrace::BytesOrWideString<'_>| path.fmt(fmt);
+        let mut f = BacktraceFmt::new(fmt, PrintFmt::Short, &mut print_path);
+        let mut ignoring = false;
+        for frame in self.trace.frames() {
+            let symbols = frame.symbols();
+            if !symbols.is_empty() {
+                let should_ignore = symbols.iter().any(|s| {
+                    if let Some(name) = s.name() {
+                        let name_str = name.to_string();
+                        ABBRIATABLE_FRAME_PREFIXES
+                            .iter()
+                            .any(|prefix| name_str.starts_with(prefix))
+                    } else {
+                        false
+                    }
+                });
+
+                if should_ignore && !ignoring {
+                    print_abbreviated(&mut f, frame)?;
+                }
+                ignoring = should_ignore;
+
+                if should_ignore {
+                    continue;
+                }
+            }
+
+            f.frame().backtrace_frame(frame)?;
+
+            if symbols.iter().any(|s| {
+                if let Some(name) = s.name() {
+                    name.to_string().starts_with("iaido::main_loop")
+                } else {
+                    false
+                }
+            }) {
+                print_abbreviated(&mut f, frame)?;
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+fn print_abbreviated(f: &mut BacktraceFmt, frame: &BacktraceFrame) -> fmt::Result {
+    f.frame().print_raw(
+        frame.ip(),
+        Some(backtrace::SymbolName::new(
+            " ... abbreviated ... ".as_bytes(),
+        )),
+        None,
+        None,
+    )
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,3 +1,5 @@
+pub mod backtrace;
+
 use std::{io, time::Duration};
 
 use crate::{editing::text::TextLine, input::Key};


### PR DESCRIPTION
Cuts out irrelevant and unhelpful frames

This takes an unwieldy stack like:

```
PANIC! "panicked at \'range end index 2 out of range for slice of length 1\', /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:1735:36"
Backtrace:
    0: backtrace::backtrace::libunwind::trace
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.63/src/backtrace/libunwind.rs:93:5
      backtrace::backtrace::trace_unsynchronized
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.63/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.63/src/backtrace/mod.rs:53:14
   2: backtrace::capture::Backtrace::create
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.63/src/capture.rs:176:9
   3: backtrace::capture::Backtrace::new
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.63/src/capture.rs:140:22
   4: iaido::prepare_panic_capture::{{closure}}
             at src/main.rs:97:21
   5: std::panicking::rust_panic_with_hook
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panicking.rs:595:17
   6: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panicking.rs:497:13
   7: std::sys_common::backtrace::__rust_end_short_backtrace
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/sys_common/backtrace.rs:141:18
   8: rust_begin_unwind
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panicking.rs:493:5
   9: core::panicking::panic_fmt
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/panicking.rs:92:14
  10: core::slice::index::slice_end_index_len_fail
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/slice/index.rs:41:5
  11: core::slice::index::range
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:544:9
  12: alloc::vec::Vec<T,A>::drain
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:1735:36
  13: alloc::vec::Vec<T,A>::splice
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:2550:25
  14: <iaido::editing::buffer::memory::MemoryBuffer as iaido::editing::buffer::Buffer>::insert_lines
             at src/editing/buffer/memory.rs:162:13
  15: <iaido::editing::buffer::memory::MemoryBuffer as iaido::editing::buffer::Buffer>::insert_range
             at src/editing/buffer/memory.rs:203:13
  16: <iaido::editing::buffer::undoable::UndoableBuffer as iaido::editing::buffer::Buffer>::insert_range
             at src/editing/buffer/undoable.rs:148:9
  17: iaido::app::state::AppState::insert_range_at_cursor
             at src/app/state.rs:250:9
  18: iaido::input::maps::vim::normal::registers::paste_before_cursor
             at src/input/maps/vim/normal/registers.rs:84:5
  19: iaido::input::maps::vim::normal::registers::paste_after_cursor
             at src/input/maps/vim/normal/registers.rs:103:5
  20: iaido::input::maps::vim::normal::registers::mappings::{{closure}}
             at src/input/maps/vim/normal/registers.rs:34:17
  21: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1560:9
  22: <iaido::input::maps::vim::VimKeymap as iaido::input::Keymap>::process
             at src/input/maps/vim/mod.rs:267:34
  23: iaido::app::looper::run_loop
             at src/app/looper.rs:180:25
  24: iaido::app::looper::app_loop
             at src/app/looper.rs:143:5
  25: iaido::main_loop
             at src/main.rs:34:5
  26: core::ops::function::FnOnce::call_once
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
  27: std::panicking::try::do_call
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:379:40
  28: <unknown>
             at src/input/mod.rs:159:15
  29: std::panicking::try
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panicking.rs:343:19
  30: std::panic::catch_unwind
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/panic.rs:431:14
  31: iaido::main::{{closure}}
             at src/main.rs:55:42
  32: <core::future::from_generator::GenFuture<T> as core::future::future::Future>::poll
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/future/mod.rs:80:19
  33: tokio::park::thread::CachedParkThread::block_on::{{closure}}
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/park/thread.rs:263:54
  34: tokio::coop::with_budget::{{closure}}
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/coop.rs:106:9
  35: std::thread::local::LocalKey<T>::try_with
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:272:16
  36: std::thread::local::LocalKey<T>::with
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/thread/local.rs:248:9
  37: tokio::coop::with_budget
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/coop.rs:99:5
      tokio::coop::budget
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/coop.rs:76:5
      tokio::park::thread::CachedParkThread::block_on
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/park/thread.rs:263:31
  38: tokio::runtime::enter::Enter::block_on
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/runtime/enter.rs:151:13
  39: tokio::runtime::thread_pool::ThreadPool::block_on
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/runtime/thread_pool/mod.rs:71:9
  40: tokio::runtime::Runtime::block_on
             at /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.4.0/src/runtime/mod.rs:452:43
  41: iaido::main
             at src/main.rs:55:22
  42: core::ops::function::FnOnce::call_once
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/ops/function.rs:227:5
  43: std::sys_common::backtrace::__rust_begin_short_backtrace
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys_common/backtrace.rs:125:18
  44: std::rt::lang_start::{{closure}}
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:66:18
  45: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/ops/function.rs:259:13
      std::panicking::try::do_call
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panicking.rs:379:40
      std::panicking::try
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panicking.rs:343:19
      std::panic::catch_unwind
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/panic.rs:431:14
      std::rt::lang_start_internal
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/std/src/rt.rs:51:25
  46: std::rt::lang_start
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/std/src/rt.rs:65:5
  47: <unknown>
             at src/input/mod.rs:159:15
```

and simplifies it down to:

```
PANIC! "panicked at \'range end index 2 out of range for slice of length 1\', /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:1735:36"
Backtrace:
    0:  ... abbreviated ...
   1: core::slice::index::slice_end_index_len_fail
             at /rustc/9bc8c42bb2f19e745a63f3445f1ac248fb015e53/library/core/src/slice/index.rs:41:5
   2: core::slice::index::range
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/core/src/slice/index.rs:544:9
   3: alloc::vec::Vec<T,A>::drain
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:1735:36
   4: alloc::vec::Vec<T,A>::splice
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/vec/mod.rs:2550:25
   5: <iaido::editing::buffer::memory::MemoryBuffer as iaido::editing::buffer::Buffer>::insert_lines
             at /Users/daniel/git/iaido/src/editing/buffer/memory.rs:162:13
   6: <iaido::editing::buffer::memory::MemoryBuffer as iaido::editing::buffer::Buffer>::insert_range
             at /Users/daniel/git/iaido/src/editing/buffer/memory.rs:203:13
   7: <iaido::editing::buffer::undoable::UndoableBuffer as iaido::editing::buffer::Buffer>::insert_range
             at /Users/daniel/git/iaido/src/editing/buffer/undoable.rs:148:9
   8: iaido::app::state::AppState::insert_range_at_cursor
             at /Users/daniel/git/iaido/src/app/state.rs:250:9
   9: iaido::input::maps::vim::normal::registers::paste_before_cursor
             at /Users/daniel/git/iaido/src/input/maps/vim/normal/registers.rs:84:5
  10: iaido::input::maps::vim::normal::registers::paste_after_cursor
             at /Users/daniel/git/iaido/src/input/maps/vim/normal/registers.rs:103:5
  11: iaido::input::maps::vim::normal::registers::mappings::{{closure}}
             at /Users/daniel/git/iaido/src/input/maps/vim/normal/registers.rs:34:17
  12: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /Users/daniel/.rustup/toolchains/stable-x86_64-apple-darwin/lib/rustlib/src/rust/library/alloc/src/boxed.rs:1560:9
  13: <iaido::input::maps::vim::VimKeymap as iaido::input::Keymap>::process
             at /Users/daniel/git/iaido/src/input/maps/vim/mod.rs:267:34
  14: iaido::app::looper::run_loop
             at /Users/daniel/git/iaido/src/app/looper.rs:180:25
  15: iaido::app::looper::app_loop
             at /Users/daniel/git/iaido/src/app/looper.rs:143:5
  16: iaido::main_loop
             at /Users/daniel/git/iaido/src/main.rs:35:5
  17:  ... abbreviated ...
```
