### PR TITLE
Improve buffer editing stability

### DIFF
--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -316,13 +316,13 @@ pub mod tests {
             self.commands.insert(command_name.to_string(), spec);
         }
 
-        pub fn feed_keys_for_state<K: Keymap>(
+        pub fn feed_keys_with_state<K: Keymap>(
             mut self,
             mut keymap: K,
+            mut state: app::State,
             keys: &str,
         ) -> (Self, app::State) {
             let key_source = MemoryKeySource::from_keys(keys);
-            let mut state = app::State::default();
 
             self.buffer = state.buffers.replace(self.buffer);
 
@@ -351,6 +351,10 @@ pub mod tests {
             (self, context.state)
         }
 
+        pub fn feed_keys_for_state<K: Keymap>(self, keymap: K, keys: &str) -> (Self, app::State) {
+            self.feed_keys_with_state(keymap, app::State::default(), keys)
+        }
+
         pub fn feed_keys<K: Keymap>(self, keymap: K, keys: &str) -> Self {
             let (result, _) = self.feed_keys_for_state(keymap, keys);
             result
@@ -358,6 +362,10 @@ pub mod tests {
 
         pub fn feed_vim(self, keys: &str) -> Self {
             self.feed_keys(crate::input::maps::vim::VimKeymap::default(), keys)
+        }
+
+        pub fn feed_vim_with_state(self, state: app::State, keys: &str) -> (Self, app::State) {
+            self.feed_keys_with_state(crate::input::maps::vim::VimKeymap::default(), state, keys)
         }
 
         pub fn feed_vim_for_state(self, keys: &str) -> (Self, app::State) {

--- a/src/input/maps/vim/normal/registers.rs
+++ b/src/input/maps/vim/normal/registers.rs
@@ -88,7 +88,7 @@ fn paste_before_cursor(state: &mut app::State, text: CopiedRange) {
     }
 }
 
-fn paste_after_cursor(state: &mut app::State, text: CopiedRange) {
+fn paste_after_cursor(state: &mut app::State, mut text: CopiedRange) {
     let single_line_width = single_line_width(&text);
 
     if single_line_width > 0 {
@@ -99,6 +99,7 @@ fn paste_after_cursor(state: &mut app::State, text: CopiedRange) {
             line: cursor.line + 1,
             col: 0,
         };
+        text.leading_newline = true;
     }
     paste_before_cursor(state, text);
 }
@@ -203,6 +204,26 @@ mod tests {
                 Take my |love
             "});
             ctx.feed_vim("Yp").assert_visual_match(indoc! {"
+                Take my love
+                |Take my love
+            "});
+        }
+
+        #[test]
+        fn paste_line_from_clipboard_after_cursor() {
+            let ctx = window(indoc! {"
+                ~
+                Take my |love
+            "});
+
+            let mut state = crate::app::State::default();
+            state
+                .registers
+                .by_name('a')
+                .write("Take my love\n".to_string());
+
+            let (mut ctx, _) = ctx.feed_vim_with_state(state, "\"ap");
+            ctx.assert_visual_match(indoc! {"
                 Take my love
                 |Take my love
             "});

--- a/src/input/maps/vim/normal/registers.rs
+++ b/src/input/maps/vim/normal/registers.rs
@@ -74,11 +74,12 @@ fn yank(ctx: &mut KeyHandlerContext<VimKeymap>, range: MotionRange) -> KeyResult
     Ok(())
 }
 
-fn paste_before_cursor(state: &mut app::State, text: CopiedRange) {
+fn paste_before_cursor(state: &mut app::State, mut text: CopiedRange) {
     let single_line_width = single_line_width(&text);
 
     if single_line_width == 0 {
         state.current_window_mut().cursor.col = 0;
+        text.leading_newline = true;
     }
 
     state.insert_range_at_cursor(text);
@@ -220,12 +221,12 @@ mod tests {
             state
                 .registers
                 .by_name('a')
-                .write("Take my love\n".to_string());
+                .write("Take my land\n".to_string());
 
             let (mut ctx, _) = ctx.feed_vim_with_state(state, "\"ap");
             ctx.assert_visual_match(indoc! {"
                 Take my love
-                |Take my love
+                |Take my land
             "});
         }
     }
@@ -248,6 +249,26 @@ mod tests {
             "});
             ctx.feed_vim("YP").assert_visual_match(indoc! {"
                 |Take my love
+                Take my love
+            "});
+        }
+
+        #[test]
+        fn paste_line_from_clipboard_before_cursor() {
+            let ctx = window(indoc! {"
+                ~
+                Take my |love
+            "});
+
+            let mut state = crate::app::State::default();
+            state
+                .registers
+                .by_name('a')
+                .write("Take my land\n".to_string());
+
+            let (mut ctx, _) = ctx.feed_vim_with_state(state, "\"aP");
+            ctx.assert_visual_match(indoc! {"
+                |Take my land
                 Take my love
             "});
         }


### PR DESCRIPTION
- Fix potential panic appending a line at the end of a buffer
- Set leading_newline flag on multi-line CopiedRange when pasting after
- Set leading_newline when pasting before as well
