### PR TITLE
Add somewhat kludgey fix to handle double "change" mappings

### DIFF
--- a/src/editing/change/handler.rs
+++ b/src/editing/change/handler.rs
@@ -17,7 +17,9 @@ impl<'a> ChangeHandler<'a> {
 
     delegate! {
         to self.changes {
+            pub fn cancel(&mut self);
             pub fn clear(&mut self);
+            pub fn is_in_change(&self) -> bool;
             pub fn push(&mut self, change: Change);
             pub fn take_last(&mut self) -> Option<Change>;
         }

--- a/src/editing/change/manager.rs
+++ b/src/editing/change/manager.rs
@@ -28,6 +28,11 @@ impl ChangeManager {
         }
     }
 
+    /// Returns true *if* we're in the middle of a pending change
+    pub fn is_in_change(&self) -> bool {
+        self.change_depth > 0
+    }
+
     pub fn push_change_key(&mut self, key: Key) {
         if let Some(change) = self.current_change.as_mut() {
             change.keys.push(key);
@@ -58,12 +63,18 @@ impl ChangeManager {
             .push(action);
     }
 
+    pub fn cancel(&mut self) {
+        self.current_change = None;
+        self.change_depth = 0;
+    }
+
     /// After reading in a file, for example, we should not have
     /// any undo history
     pub fn clear(&mut self) {
         self.undo_stack.clear();
         self.redo_stack.clear();
         self.current_change = None;
+        self.change_depth = 0;
     }
 
     pub fn push(&mut self, change: Change) {

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -321,7 +321,7 @@ pub mod tests {
             mut keymap: K,
             mut state: app::State,
             keys: &str,
-        ) -> (Self, app::State) {
+        ) -> (Self, K, app::State) {
             let key_source = MemoryKeySource::from_keys(keys);
 
             self.buffer = state.buffers.replace(self.buffer);
@@ -348,11 +348,12 @@ pub mod tests {
             self.buffer = context.state.buffers.replace(self.buffer);
             self.window.cursor = context.state.current_window_mut().cursor;
 
-            (self, context.state)
+            (self, keymap, context.state)
         }
 
         pub fn feed_keys_for_state<K: Keymap>(self, keymap: K, keys: &str) -> (Self, app::State) {
-            self.feed_keys_with_state(keymap, app::State::default(), keys)
+            let (ctx, _, state) = self.feed_keys_with_state(keymap, app::State::default(), keys);
+            (ctx, state)
         }
 
         pub fn feed_keys<K: Keymap>(self, keymap: K, keys: &str) -> Self {
@@ -364,8 +365,25 @@ pub mod tests {
             self.feed_keys(crate::input::maps::vim::VimKeymap::default(), keys)
         }
 
+        pub fn feed_vim_for_keymap(
+            self,
+            keys: &str,
+        ) -> (Self, crate::input::maps::vim::VimKeymap, app::State) {
+            let (ctx, keymap, state) = self.feed_keys_with_state(
+                crate::input::maps::vim::VimKeymap::default(),
+                app::State::default(),
+                keys,
+            );
+            (ctx, keymap, state)
+        }
+
         pub fn feed_vim_with_state(self, state: app::State, keys: &str) -> (Self, app::State) {
-            self.feed_keys_with_state(crate::input::maps::vim::VimKeymap::default(), state, keys)
+            let (ctx, _, state) = self.feed_keys_with_state(
+                crate::input::maps::vim::VimKeymap::default(),
+                state,
+                keys,
+            );
+            (ctx, state)
         }
 
         pub fn feed_vim_for_state(self, keys: &str) -> (Self, app::State) {

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -58,7 +58,7 @@ pub fn vim_insert_mappings() -> KeyTreeNode {
 
 fn common_insert_mode(extra_mappings: Option<KeyTreeNode>) -> VimMode {
     let mut mappings = vim_tree! {
-        "<esc>" => |ctx| {
+        "<esc>" => |?cancel ctx| {
             ctx.state_mut().clear_echo();
             ctx.state_mut().current_window_mut().set_inserting(false);
             ctx.state_mut().current_buffer_mut().end_change();

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -276,8 +276,9 @@ pub fn vim_normal_mode() -> VimMode {
         + vim_linewise_motions();
 
     VimMode::new("n", mappings).on_default(key_handler!(
-        VimKeymap | ?mut ctx | {
+        VimKeymap | ctx | {
             ctx.keymap.reset();
+            ctx.cancel_change();
             Ok(())
         }
     ))

--- a/src/input/maps/vim/normal/change.rs
+++ b/src/input/maps/vim/normal/change.rs
@@ -167,4 +167,27 @@ mod tests {
             "});
         }
     }
+
+    #[test]
+    fn changes_should_clear_on_invalid_map() {
+        // cI should never do anything by default, since c would
+        // go into operator pending and I does nothing there
+        let (mut ctx, keymap, _) = window(indoc! {"
+            Take my |love
+        "})
+        .feed_vim_for_keymap("cI<esc>"); // TODO with op pending mode, <esc> should be unneeded
+        assert!(keymap.operator_fn.is_none());
+        assert!(!ctx.buffer.changes().is_in_change());
+    }
+
+    #[test]
+    fn changes_should_clear_on_unmapped() {
+        // c<c-q> should never do anything since <c-q> is unbound
+        let (mut ctx, keymap, _) = window(indoc! {"
+            Take my |love
+        "})
+        .feed_vim_for_keymap("c<c-q>");
+        assert!(keymap.operator_fn.is_none());
+        assert!(!ctx.buffer.changes().is_in_change());
+    }
 }


### PR DESCRIPTION
See the tests; actually, something like `cI` should do *nothing* because
`I` is unmapped in operator pending mode. Hopefully we can mostly remove
these changes once we add this mode (see #48) but I wanted to get
passing tests in to make sure we don't regress.