### PR TITLE
Add simple support for the Popup Menu (PUM)

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,6 +2,7 @@ pub mod bufwin;
 pub mod help;
 pub mod jobs;
 pub mod looper;
+pub mod popup;
 pub mod prompt;
 pub mod registers;
 pub mod state;

--- a/src/app/popup.rs
+++ b/src/app/popup.rs
@@ -1,0 +1,36 @@
+use std::convert::TryInto;
+
+use crate::editing::Size;
+
+pub struct PopupMenu {
+    pub contents: Vec<String>,
+
+    /// Selected index within `contents`, if any
+    pub cursor: Option<usize>,
+
+    /// Offset towards the start of the line that the PUM should be
+    /// offset relative to the cursor
+    pub horizontal_offset: usize,
+}
+
+impl PopupMenu {
+    pub fn measure(&self, size: Size) -> Size {
+        let width = std::cmp::min(
+            size.w.checked_sub(2).unwrap_or(1),
+            self.contents
+                .iter()
+                .map(|item| item.len())
+                .max()
+                .unwrap_or(0)
+                .try_into()
+                .unwrap_or(1),
+        );
+
+        let height = std::cmp::min(
+            (size.h / 2).checked_sub(2).unwrap_or(1),
+            self.contents.len().try_into().unwrap_or(1),
+        );
+
+        (width, height).into()
+    }
+}

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -291,15 +291,7 @@ impl Default for AppState {
             tabpages,
             registers: RegisterManager::new(),
             echo_buffer: Box::new(MemoryBuffer::new(0)),
-            pum: Some(PopupMenu {
-                contents: vec![
-                    "Al pastor".to_string(),
-                    "Chorizo".to_string(),
-                    "Queso".to_string(),
-                ],
-                cursor: Some(2),
-                horizontal_offset: 0,
-            }),
+            pum: None,
             prompt: Prompt::default(),
             builtin_commands: create_builtin_commands(),
             keymap_widget: None,

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -25,6 +25,7 @@ use crate::{
 use super::{
     bufwin::BufWin,
     jobs::{JobError, Jobs},
+    popup::PopupMenu,
     prompt::Prompt,
     registers::RegisterManager,
     widgets::Widget,
@@ -39,6 +40,7 @@ pub struct AppState {
     pub buffers: Buffers,
     pub tabpages: Tabpages,
     pub echo_buffer: Box<dyn Buffer>,
+    pub pum: Option<PopupMenu>,
     pub prompt: Prompt,
     pub builtin_commands: CommandRegistry,
     pub registers: RegisterManager,
@@ -289,6 +291,15 @@ impl Default for AppState {
             tabpages,
             registers: RegisterManager::new(),
             echo_buffer: Box::new(MemoryBuffer::new(0)),
+            pum: Some(PopupMenu {
+                contents: vec![
+                    "Al pastor".to_string(),
+                    "Chorizo".to_string(),
+                    "Queso".to_string(),
+                ],
+                cursor: Some(2),
+                horizontal_offset: 0,
+            }),
             prompt: Prompt::default(),
             builtin_commands: create_builtin_commands(),
             keymap_widget: None,

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -60,25 +60,27 @@ impl CompletionState {
     }
 
     pub fn to_pum(&self) -> Option<PopupMenu> {
-        if self.completions.is_none() && self.history.is_empty() {
+        if self.completions.is_none() && self.history.len() < 2 {
+            // NOTE: The first "history" item is the raw input
             return None;
         }
 
         let contents: Vec<String> = self
             .history
             .iter()
+            .skip(1)
             .map(|completion| completion.replacement.to_string())
             .collect();
 
         let mut horizontal_offset = 0usize;
 
-        if let Some(item) = self.history.get(0) {
+        if let Some(item) = self.history.get(1) {
             horizontal_offset = item.end - item.start;
         }
 
         Some(PopupMenu {
             contents,
-            cursor: Some(self.index),
+            cursor: self.index.checked_sub(1),
             horizontal_offset,
         })
     }

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -75,8 +75,8 @@ impl CompletionState {
 
         let mut horizontal_offset = 0usize;
 
-        if let Some(item) = self.history.get(1) {
-            horizontal_offset = item.end - item.start;
+        if let Some(item) = self.history.get(self.index.checked_sub(1).unwrap_or(0)) {
+            horizontal_offset = item.replacement_end().col - item.start;
         }
 
         Some(PopupMenu {

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -73,11 +73,12 @@ impl CompletionState {
             .map(|completion| completion.replacement.to_string())
             .collect();
 
-        let mut horizontal_offset = 0usize;
-
-        if let Some(item) = self.history.get(self.index.checked_sub(1).unwrap_or(0)) {
-            horizontal_offset = item.replacement_end().col - item.start;
-        }
+        let horizontal_offset =
+            if let Some(item) = self.history.get(self.index.checked_sub(1).unwrap_or(0)) {
+                item.replacement_end().col - item.start
+            } else {
+                0usize
+            };
 
         Some(PopupMenu {
             contents,

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -60,8 +60,9 @@ impl CompletionState {
     }
 
     pub fn to_pum(&self) -> Option<PopupMenu> {
+        // NOTE: The first "history" item is the raw input; that's the source
+        // of the extra 1 everywhere in here:
         if self.completions.is_none() && self.history.len() < 2 {
-            // NOTE: The first "history" item is the raw input
             return None;
         }
 
@@ -80,7 +81,7 @@ impl CompletionState {
 
         Some(PopupMenu {
             contents,
-            cursor: self.index.checked_sub(1),
+            cursor: self.index.checked_sub(2),
             horizontal_offset,
         })
     }

--- a/src/input/completion/state.rs
+++ b/src/input/completion/state.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use crate::{editing::motion::MotionContext, input::KeymapContext};
+use crate::{app::popup::PopupMenu, editing::motion::MotionContext, input::KeymapContext};
 
 use super::{CompletableContext, Completer, Completion, CompletionContext};
 
@@ -57,6 +57,30 @@ impl CompletionState {
             history: vec![original],
             index: 1,
         }
+    }
+
+    pub fn to_pum(&self) -> Option<PopupMenu> {
+        if self.completions.is_none() && self.history.is_empty() {
+            return None;
+        }
+
+        let contents: Vec<String> = self
+            .history
+            .iter()
+            .map(|completion| completion.replacement.to_string())
+            .collect();
+
+        let mut horizontal_offset = 0usize;
+
+        if let Some(item) = self.history.get(0) {
+            horizontal_offset = item.end - item.start;
+        }
+
+        Some(PopupMenu {
+            contents,
+            cursor: Some(self.index),
+            horizontal_offset,
+        })
     }
 
     pub fn apply_next<C: MotionContext>(&mut self, ctx: &mut C) {

--- a/src/input/maps/vim/insert.rs
+++ b/src/input/maps/vim/insert.rs
@@ -39,7 +39,7 @@ pub fn vim_insert_mappings() -> KeyTreeNode {
             };
 
             state.apply_next(ctx.state_mut());
-
+            ctx.state_mut().pum = state.to_pum();
             ctx.state_mut().current_window_mut().completion_state = Some(state);
 
             Ok(())
@@ -48,6 +48,7 @@ pub fn vim_insert_mappings() -> KeyTreeNode {
             if let Some(mut state) = ctx.state_mut().current_window_mut().completion_state.take() {
                 state.apply_prev(ctx.state_mut());
 
+                ctx.state_mut().pum = state.to_pum();
                 ctx.state_mut().current_window_mut().completion_state = Some(state);
             }
 

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -238,9 +238,6 @@ impl Keymap for VimKeymap {
 
         if !show_keys && !self.keys_buffer.is_empty() {
             self.keys_buffer.clear();
-        } else if show_keys {
-            // Clear the popup menu, if any
-            context.state_mut().pum = None;
         }
 
         let mut current = &mode.mappings;
@@ -253,6 +250,9 @@ impl Keymap for VimKeymap {
                 if show_keys {
                     self.keys_buffer.push(key.clone());
                 }
+
+                // Clear the popup menu, if any
+                context.state_mut().pum = None;
 
                 // if there's a change in progress, add the key to it
                 if !context.state().current_buffer().is_read_only() {

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -238,6 +238,9 @@ impl Keymap for VimKeymap {
 
         if !show_keys && !self.keys_buffer.is_empty() {
             self.keys_buffer.clear();
+        } else if show_keys {
+            // Clear the popup menu, if any
+            context.state_mut().pum = None;
         }
 
         let mut current = &mode.mappings;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,18 +1,18 @@
 use crate::{
-    app::widgets::Widget,
+    app::{popup::PopupMenu, widgets::Widget},
     editing::{self, Resizable, Size},
     ui::UI,
 };
 
 use crossterm::terminal;
 use editing::window::Window;
-use std::{cmp::min, io};
+use std::{cmp::min, convert::TryInto, io};
 use tui::{
     backend::Backend,
     style::{Color, Style},
     text::Span,
-    widgets::Block,
-    Frame, Terminal,
+    widgets::{Block, ListState},
+    Terminal,
 };
 use tui::{backend::CrosstermBackend, layout::Rect};
 pub use tui::{
@@ -84,6 +84,15 @@ impl Tui {
 
         // prompt
         self.render_prompt(app, &mut display);
+
+        // popup menu
+        if let Some(pum) = app.pum.as_ref() {
+            match display.cursor.clone() {
+                editing::Cursor::Line(x, y) => Tui::render_pum(pum, x, y, &mut display),
+                editing::Cursor::Block(x, y) => Tui::render_pum(pum, x, y, &mut display),
+                _ => {} // nop
+            }
+        }
 
         // render any active keymap widget
         if let Some(w) = &app.keymap_widget {
@@ -197,11 +206,9 @@ impl Tui {
                 editing::Cursor::None => { /* nop */ }
                 editing::Cursor::Block(x, y) => {
                     f.set_cursor(x, y);
-                    Tui::render_pum(f, x, y);
                 }
                 editing::Cursor::Line(x, y) => {
                     f.set_cursor(x, y);
-                    Tui::render_pum(f, x, y);
                 }
             }
         })?;
@@ -209,38 +216,41 @@ impl Tui {
         self.cursor.render(cursor)
     }
 
-    fn render_pum(f: &mut Frame<CrosstermBackend<io::Stdout>>, x: u16, y: u16) {
-        let list = List::new(vec![
-            ListItem::new(Span::raw("Al pastor")),
-            ListItem::new(Span::raw("Chorizo")),
-            ListItem::new(Span::raw("Queso")),
-        ])
+    fn render_pum(pum: &PopupMenu, x: u16, y: u16, display: &mut Display) {
+        let list = List::new(
+            pum.contents
+                .iter()
+                .map(|item| ListItem::new(Span::raw(item)))
+                .collect::<Vec<ListItem>>(),
+        )
+        .highlight_style(Style::default().bg(Color::LightBlue))
         .block(Block::default().style(Style::default().bg(Color::Blue)));
 
-        // TODO compute/provide these dimensions:
-        let height = 3;
-        let width = 10;
+        let mut list_state = ListState::default();
+        list_state.select(pum.cursor);
 
-        let x = if x + width > f.size().width {
-            f.size().width - width
+        let Size { w, h } = pum.measure(display.size);
+
+        let requested_x = x
+            .checked_sub(pum.horizontal_offset.try_into().unwrap_or(0))
+            .unwrap_or(0);
+        let x = if requested_x + w > display.size.w {
+            display.size.w - w
         } else {
-            x
+            requested_x
         };
 
-        let y = if y + 1 + height > f.size().height {
-            y.checked_sub(height).unwrap_or(1u16)
+        let y = if y + 1 + h > display.size.h {
+            y.checked_sub(h).unwrap_or(1u16)
         } else {
             y + 1
         };
 
-        f.render_widget(
+        tui::widgets::StatefulWidget::render(
             list,
-            Rect {
-                x,
-                y,
-                width,
-                height,
-            },
+            Rect::new(x, y, w, h),
+            &mut display.buffer,
+            &mut list_state,
         );
     }
 }

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,9 +7,18 @@ use crate::{
 use crossterm::terminal;
 use editing::window::Window;
 use std::{cmp::min, io};
-pub use tui::text;
-use tui::{backend::Backend, Terminal};
+use tui::{
+    backend::Backend,
+    style::{Color, Style},
+    text::Span,
+    widgets::Block,
+    Frame, Terminal,
+};
 use tui::{backend::CrosstermBackend, layout::Rect};
+pub use tui::{
+    text,
+    widgets::{List, ListItem},
+};
 
 pub mod cursor;
 pub mod events;
@@ -188,14 +197,51 @@ impl Tui {
                 editing::Cursor::None => { /* nop */ }
                 editing::Cursor::Block(x, y) => {
                     f.set_cursor(x, y);
+                    Tui::render_pum(f, x, y);
                 }
                 editing::Cursor::Line(x, y) => {
                     f.set_cursor(x, y);
+                    Tui::render_pum(f, x, y);
                 }
             }
         })?;
 
         self.cursor.render(cursor)
+    }
+
+    fn render_pum(f: &mut Frame<CrosstermBackend<io::Stdout>>, x: u16, y: u16) {
+        let list = List::new(vec![
+            ListItem::new(Span::raw("Al pastor")),
+            ListItem::new(Span::raw("Chorizo")),
+            ListItem::new(Span::raw("Queso")),
+        ])
+        .block(Block::default().style(Style::default().bg(Color::Blue)));
+
+        // TODO compute/provide these dimensions:
+        let height = 3;
+        let width = 10;
+
+        let x = if x + width > f.size().width {
+            f.size().width - width
+        } else {
+            x
+        };
+
+        let y = if y + 1 + height > f.size().height {
+            y.checked_sub(height).unwrap_or(1u16)
+        } else {
+            y + 1
+        };
+
+        f.render_widget(
+            list,
+            Rect {
+                x,
+                y,
+                width,
+                height,
+            },
+        );
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -246,12 +246,10 @@ impl Tui {
             y + 1
         };
 
-        tui::widgets::StatefulWidget::render(
-            list,
-            Rect::new(x, y, w, h),
-            &mut display.buffer,
-            &mut list_state,
-        );
+        let area = Rect::new(x, y, w, h);
+        display.clear(area);
+
+        tui::widgets::StatefulWidget::render(list, area, &mut display.buffer, &mut list_state);
     }
 }
 

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -240,7 +240,7 @@ impl Tui {
             requested_x
         };
 
-        let y = if y + 1 + h > display.size.h {
+        let y = if y + 1 + h > display.size.h / 2 {
             y.checked_sub(h).unwrap_or(1u16)
         } else {
             y + 1

--- a/src/tui/rendering/display.rs
+++ b/src/tui/rendering/display.rs
@@ -1,4 +1,4 @@
-use tui::layout::Rect;
+use tui::{buffer::Cell, layout::Rect};
 
 use crate::editing::{self, Size};
 
@@ -14,6 +14,16 @@ impl Display {
             size,
             buffer: tui::buffer::Buffer::empty(size.into()),
             cursor: editing::Cursor::None,
+        }
+    }
+
+    pub fn clear(&mut self, area: Rect) {
+        let width: usize = area.width.into();
+        for y in area.y..area.y + area.height {
+            let start = self.buffer.index_of(area.x, y);
+            for x in start..start + width {
+                self.buffer.content[x] = Cell::default();
+            }
         }
     }
 


### PR DESCRIPTION
<img width="682" alt="Screen Shot 2021-12-13 at 11 42 21 PM" src="https://user-images.githubusercontent.com/816150/145934365-612933c6-0d56-479c-8b59-3cdb1db5fbf9.png">

This includes:
- Rendering whatever is set in `state.pum` (if anything), clearing out text "beneath" it and adjusting positioning to fit
- Showing PUM on `<tab>` and `<s-tab>`
- Rendering a PUM based on a "preload" of the first `N` completion suggestions