### PR TITLE
Add text objects for "pairs" of characters

### DIFF
--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -22,7 +22,7 @@ pub struct Size {
     pub h: u16,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord)]
 pub struct CursorPosition {
     /// Line index within a buffer
     pub line: usize,

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -24,6 +24,10 @@ bitflags! {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct MotionRange(pub CursorPosition, pub CursorPosition, pub MotionFlags);
 impl MotionRange {
+    pub fn is_empty(&self) -> bool {
+        self.0 == self.1
+    }
+
     pub fn lines(&self) -> (usize, usize) {
         let &MotionRange(
             CursorPosition {

--- a/src/editing/object/mod.rs
+++ b/src/editing/object/mod.rs
@@ -1,6 +1,7 @@
 use super::motion::{Motion, MotionContext, MotionFlags, MotionRange};
 
 pub mod pair;
+mod util;
 pub mod word;
 
 pub trait TextObject {

--- a/src/editing/object/mod.rs
+++ b/src/editing/object/mod.rs
@@ -1,5 +1,6 @@
 use super::motion::{Motion, MotionContext, MotionFlags, MotionRange};
 
+pub mod pair;
 pub mod word;
 
 pub trait TextObject {
@@ -12,8 +13,8 @@ impl<T: TextObject> Motion for T {
     }
 
     fn range<C: MotionContext>(&self, context: &C) -> MotionRange {
-        let inclusive = !self.flags().contains(MotionFlags::EXCLUSIVE);
         let MotionRange(start, mut end, flags) = self.object_range(context);
+        let inclusive = !flags.contains(MotionFlags::EXCLUSIVE);
 
         if inclusive {
             end.col += 1;

--- a/src/editing/object/pair.rs
+++ b/src/editing/object/pair.rs
@@ -50,6 +50,10 @@ impl InnerPairObject {
 }
 
 fn char_at<C: MotionContext>(context: &C, cursor: CursorPosition) -> char {
+    if context.buffer().is_empty() {
+        return '\0';
+    }
+
     if let Some(s) = context.buffer().get_char(cursor) {
         if let Some(ch) = s.chars().next() {
             ch
@@ -117,7 +121,7 @@ pub struct OuterPairObject {
 impl TextObject for OuterPairObject {
     fn object_range<C: MotionContext>(&self, context: &C) -> MotionRange {
         let mut range = self.inner.object_range(context);
-        if range.is_empty() {
+        if range.is_empty() || range.0.col == 0 {
             return range;
         }
 
@@ -175,6 +179,15 @@ mod tests {
             assert_eq!(
                 ctx.select(InnerPairObject::within_line('\'', '\'').into_outer()),
                 "'queso' "
+            );
+        }
+
+        #[test]
+        fn outer_from_empty() {
+            let ctx = window("");
+            assert_eq!(
+                ctx.select(InnerPairObject::within_line('\'', '\'').into_outer()),
+                ""
             );
         }
 

--- a/src/editing/object/util.rs
+++ b/src/editing/object/util.rs
@@ -1,0 +1,36 @@
+use crate::editing::{
+    motion::{char::CharMotion, Motion, MotionContext},
+    CursorPosition,
+};
+
+fn is_whitespace(end: Option<&str>) -> bool {
+    if let Some(s) = end {
+        s.find(char::is_whitespace).is_some()
+    } else {
+        false
+    }
+}
+
+pub fn follow_whitespace<C: MotionContext>(
+    context: &C,
+    start: CursorPosition,
+    step: CharMotion,
+) -> CursorPosition {
+    let buffer = context.buffer();
+    let mut end = start;
+
+    let line_width = match buffer.get_line_width(end.line) {
+        Some(width) => width,
+        _ => return end,
+    };
+
+    loop {
+        let new_end = step.destination(&context.with_cursor(end));
+        if new_end.col >= line_width || new_end == end || !is_whitespace(buffer.get_char(new_end)) {
+            break;
+        }
+        end = new_end;
+    }
+
+    end
+}

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -343,6 +343,20 @@ mod tests {
         }
 
         #[test]
+        fn text_object() {
+            let ctx = window(indoc! {"
+                Take my love
+                Take m|y land
+                Take me where
+            "});
+            ctx.feed_vim("caw").assert_visual_match(indoc! {"
+                Take my love
+                Take |land
+                Take me where
+            "});
+        }
+
+        #[test]
         fn with_motion_adds_keys_to_change() {
             let mut ctx = window(indoc! {"
                 Take my love

--- a/src/input/maps/vim/object.rs
+++ b/src/input/maps/vim/object.rs
@@ -16,20 +16,33 @@ pub fn vim_standard_objects() -> KeyTreeNode {
 
         "i]" => motion { InnerPairObject::new('[', ']') },
         "i[" => motion { InnerPairObject::new('[', ']') },
+        "a]" => motion { InnerPairObject::new('[', ']').into_outer() },
+        "a[" => motion { InnerPairObject::new('[', ']').into_outer() },
 
         "i)" => motion { InnerPairObject::new('(', ')') },
         "i(" => motion { InnerPairObject::new('(', ')') },
         "ib" => motion { InnerPairObject::new('(', ')') },
+        "a)" => motion { InnerPairObject::new('(', ')').into_outer() },
+        "a(" => motion { InnerPairObject::new('(', ')').into_outer() },
+        "ab" => motion { InnerPairObject::new('(', ')').into_outer() },
 
         "i>" => motion { InnerPairObject::new('<', '>') },
         "i<" => motion { InnerPairObject::new('<', '>') },
+        "a>" => motion { InnerPairObject::new('<', '>').into_outer() },
+        "a<" => motion { InnerPairObject::new('<', '>').into_outer() },
 
         "i}" => motion { InnerPairObject::new('{', '}') },
         "i{" => motion { InnerPairObject::new('{', '}') },
         "ib" => motion { InnerPairObject::new('{', '}') },
+        "a}" => motion { InnerPairObject::new('{', '}').into_outer() },
+        "a{" => motion { InnerPairObject::new('{', '}').into_outer() },
+        "ab" => motion { InnerPairObject::new('{', '}').into_outer() },
 
         "i\"" => motion { InnerPairObject::within_line('"', '"') },
         "i'" => motion { InnerPairObject::within_line('\'', '\'') },
         "i`" => motion { InnerPairObject::within_line('`', '`') },
+        "a\"" => motion { InnerPairObject::within_line('"', '"').into_outer() },
+        "a'" => motion { InnerPairObject::within_line('\'', '\'').into_outer() },
+        "a`" => motion { InnerPairObject::within_line('`', '`').into_outer() },
     }
 }

--- a/src/input/maps/vim/object.rs
+++ b/src/input/maps/vim/object.rs
@@ -1,4 +1,5 @@
 use crate::editing::motion::word::{is_big_word_boundary, is_small_word_boundary};
+use crate::editing::object::pair::InnerPairObject;
 use crate::editing::object::word::WordObject;
 use crate::input::maps::vim::VimKeymap;
 use crate::vim_tree;
@@ -12,5 +13,23 @@ pub fn vim_standard_objects() -> KeyTreeNode {
         "iW" => motion { WordObject::inner(is_big_word_boundary) },
         "aw" => motion { WordObject::outer(is_small_word_boundary) },
         "aW" => motion { WordObject::outer(is_big_word_boundary) },
+
+        "i]" => motion { InnerPairObject::new('[', ']') },
+        "i[" => motion { InnerPairObject::new('[', ']') },
+
+        "i)" => motion { InnerPairObject::new('(', ')') },
+        "i(" => motion { InnerPairObject::new('(', ')') },
+        "ib" => motion { InnerPairObject::new('(', ')') },
+
+        "i>" => motion { InnerPairObject::new('<', '>') },
+        "i<" => motion { InnerPairObject::new('<', '>') },
+
+        "i}" => motion { InnerPairObject::new('{', '}') },
+        "i{" => motion { InnerPairObject::new('{', '}') },
+        "ib" => motion { InnerPairObject::new('{', '}') },
+
+        "i\"" => motion { InnerPairObject::within_line('"', '"') },
+        "i'" => motion { InnerPairObject::within_line('\'', '\'') },
+        "i`" => motion { InnerPairObject::within_line('`', '`') },
     }
 }


### PR DESCRIPTION
Closes #48 

- Add initial support for "inner" pair objects
- Add initial support for "outer" text object

Also fixes some issues with "word" text objects