### PR TITLE
Switch the project toolchain to use nightly

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
See #59

This improves incremental compile times by *quite a bit*! A simple,
incremental `cargo check` goes from:

```
    Checking iaido v0.1.0 (/Users/daniel/git/iaido)
    Finished dev [unoptimized + debuginfo] target(s) in 1.85s
```

to:

```
    Checking iaido v0.1.0 (/Users/daniel/git/iaido)
    Finished dev [unoptimized + debuginfo] target(s) in 0.92s
```
