### PR TITLE
Fix strange cursor jumping behavior at bottom of a wrapped doc

### DIFF
--- a/src/tui/window.rs
+++ b/src/tui/window.rs
@@ -181,12 +181,16 @@ impl Renderable for Window {
                 .checked_sub((self.cursor.line - renderable.end.line) as u32)
                 .unwrap_or(0);
         } else {
-            if cursor_y_offset < renderable.start.visual_offset {
+            if self.cursor.line == renderable.start.line
+                && cursor_y_offset < renderable.start.visual_offset
+            {
                 self.scroll_lines(
                     buf,
                     (renderable.start.visual_offset - cursor_y_offset) as i32,
                 );
-            } else if cursor_y_offset > renderable.end.visual_offset {
+            } else if self.cursor.line == renderable.end.line
+                && cursor_y_offset > renderable.end.visual_offset
+            {
                 self.scroll_lines(
                     buf,
                     (renderable.end.visual_offset as i32) - cursor_y_offset as i32,

--- a/src/tui/window.rs
+++ b/src/tui/window.rs
@@ -620,6 +620,27 @@ mod tests {
         }
 
         #[test]
+        fn move_cursor_past_end_of_wrapped_document() {
+            let mut ctx = window(indoc! {"
+                Take my land Take me where
+                I cannot |stand
+            "});
+            ctx.window.resize(Size { w: 13, h: 2 });
+            ctx.render_at_own_size().assert_visual_match(indoc! {"
+                I cannot
+                |stand
+            "});
+
+            // Should be no change:
+            ctx.feed_vim("j")
+                .render_at_own_size()
+                .assert_visual_match(indoc! {"
+                I cannot
+                |stand
+            "});
+        }
+
+        #[test]
         fn move_cursor_upward_with_scroll_offsets() {
             let mut ctx = window(indoc! {"
                 Take my land Take me where I cannot |stand


### PR DESCRIPTION
- Add test for strange scrolling behavior
- Fix strange cursor jumping behavior at bottom of a wrapped doc

Easiest repro is to:

1. Fill a screen's worth of buffer, at least (possibly by connecting to a MU*)
2. Use `:vsp` to make the buffer somewhat narrow, and force wrapping
3. Jump to the bottom with `G`
4. Hit `j` to scroll "down" (this should be a no-op since the cursor is at the bottom already)