### PR TITLE
Fix inability to yank in read-only buffers; fill in some missing read-only checks

### DIFF
--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -494,6 +494,32 @@ fn render_keys_buffer(keys: &Vec<Key>) -> String {
 // ======= Tree-building macros ===========================
 
 #[macro_export]
+macro_rules! operator_handler {
+    (
+        $keys:literal => $ctx_name:ident, $motion_name:ident, $body:expr,
+        $after_body:expr
+    ) => {{
+        // Save a closure for motion use
+        let count = $ctx_name.keymap.take_count();
+        $ctx_name.keymap.count_multiplier = Some(count);
+        $ctx_name.keymap.operator_fn = Some(Box::new(|mut $ctx_name, $motion_name| {
+            let operator_fn_result = $body;
+
+            $after_body
+
+            operator_fn_result
+        }));
+
+        // Enter Operator-Pending mode
+        let allows_linewise = $ctx_name.keymap.allows_linewise();
+        let op_mode =
+            crate::input::maps::vim::op::vim_operator_pending_mode(allows_linewise, $keys.into());
+        $ctx_name.keymap.push_mode(op_mode);
+        Ok(())
+    }};
+}
+
+#[macro_export]
 macro_rules! vim_branches {
     // base case:
     ($root:ident ->) => {
@@ -574,32 +600,28 @@ macro_rules! vim_branches {
     ) => {{
         $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |$ctx_name| {
             if $ctx_name.state().current_buffer().is_read_only() {
-                return Err(KeyError::ReadOnlyBuffer);
+                return Err(crate::input::KeyError::ReadOnlyBuffer);
             }
 
             // Operators always start a change
             $ctx_name.state_mut().request_redraw();
             $ctx_name.state_mut().current_bufwin().begin_keys_change($keys);
 
-            // Save a closure for motion use
-            let count = $ctx_name.keymap.take_count();
-            $ctx_name.keymap.count_multiplier = Some(count);
-            $ctx_name.keymap.operator_fn = Some(Box::new(|mut $ctx_name, $motion_name| {
-                let operator_fn_result = $body;
-
+            crate::operator_handler!($keys => $ctx_name, $motion_name, $body, {
                 $ctx_name.state_mut().current_buffer_mut().end_change();
+            })
+        }));
+        crate::vim_branches! { $root -> $($tail)* }
+    }};
 
-                operator_fn_result
-            }));
-
-            // Enter Operator-Pending mode
-            let allows_linewise = $ctx_name.keymap.allows_linewise();
-            let op_mode = crate::input::maps::vim::op::vim_operator_pending_mode(
-                allows_linewise,
-                $keys.into(),
-            );
-            $ctx_name.keymap.push_mode(op_mode);
-            Ok(())
+    (
+        $root:ident ->
+        $keys:literal =>
+            operator ?change |$ctx_name:ident, $motion_name:ident| $body:expr,
+        $($tail:tt)*
+    ) => {{
+        $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |$ctx_name| {
+            crate::operator_handler!($keys => $ctx_name, $motion_name, $body, {})
         }));
         crate::vim_branches! { $root -> $($tail)* }
     }};

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -7,6 +7,7 @@ mod object;
 mod op;
 mod prompt;
 mod tree;
+mod util;
 
 use std::any::Any;
 use std::{collections::HashMap, ops, rc::Rc};
@@ -548,9 +549,7 @@ macro_rules! vim_branches {
         $($tail:tt)*
     ) => {
         $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |$ctx_name| {
-            if $ctx_name.state().current_buffer().is_read_only() {
-                return Err(KeyError::ReadOnlyBuffer);
-            }
+            crate::input::maps::vim::util::verify_can_edit(&$ctx_name)?;
             $ctx_name.state_mut().request_redraw();
             $ctx_name.state_mut().current_bufwin().begin_keys_change($keys);
             $body
@@ -599,9 +598,7 @@ macro_rules! vim_branches {
         $($tail:tt)*
     ) => {{
         $root.insert(&$keys.into_keys(), crate::key_handler!(VimKeymap |$ctx_name| {
-            if $ctx_name.state().current_buffer().is_read_only() {
-                return Err(crate::input::KeyError::ReadOnlyBuffer);
-            }
+            crate::input::maps::vim::util::verify_can_edit(&$ctx_name)?;
 
             // Operators always start a change
             $ctx_name.state_mut().request_redraw();

--- a/src/input/maps/vim/normal/change.rs
+++ b/src/input/maps/vim/normal/change.rs
@@ -1,15 +1,13 @@
 use crate::input::maps::vim::tree::KeyTreeNode;
+use crate::input::maps::vim::util::verify_can_edit;
 use crate::input::maps::vim::VimKeymap;
-use crate::input::maps::KeyError;
 use crate::input::KeymapContext;
 use crate::vim_tree;
 
 pub fn mappings() -> KeyTreeNode {
     vim_tree! {
         "u" => |ctx| {
-            if ctx.state().current_buffer().is_read_only() {
-                return Err(KeyError::ReadOnlyBuffer);
-            }
+            verify_can_edit(&ctx)?;
 
             ctx.state_mut().request_redraw();
             if ctx.state_mut().current_bufwin().undo() {
@@ -21,9 +19,7 @@ pub fn mappings() -> KeyTreeNode {
             Ok(())
         },
         "<ctrl-r>" => |ctx| {
-            if ctx.state().current_buffer().is_read_only() {
-                return Err(KeyError::ReadOnlyBuffer);
-            }
+            verify_can_edit(&ctx)?;
 
             ctx.state_mut().request_redraw();
             if ctx.state_mut().current_bufwin().redo() {
@@ -36,9 +32,7 @@ pub fn mappings() -> KeyTreeNode {
         },
 
         "." => |ctx| {
-            if ctx.state().current_buffer().is_read_only() {
-                return Err(KeyError::ReadOnlyBuffer);
-            }
+            verify_can_edit(&ctx)?;
 
             ctx.state_mut().request_redraw();
             if let Some(last) = ctx.state_mut().current_buffer_mut().changes().take_last() {

--- a/src/input/maps/vim/normal/registers.rs
+++ b/src/input/maps/vim/normal/registers.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     input::{
         maps::{
-            vim::{tree::KeyTreeNode, VimKeymap},
+            vim::{tree::KeyTreeNode, util::verify_can_edit, VimKeymap},
             KeyHandlerContext, KeyResult,
         },
         Key, KeyCode, KeySource, KeymapContext,
@@ -30,6 +30,7 @@ pub fn mappings() -> KeyTreeNode {
          },
 
         "p" => |ctx| {
+            verify_can_edit(&ctx)?;
             if let Some(to_paste) = read_register(&mut ctx) {
                 paste_after_cursor(ctx.state_mut(), to_paste.into());
             }
@@ -37,6 +38,7 @@ pub fn mappings() -> KeyTreeNode {
             Ok(())
         },
         "P" => |ctx| {
+            verify_can_edit(&ctx)?;
             if let Some(to_paste) = read_register(&mut ctx) {
                 paste_before_cursor(ctx.state_mut(), to_paste.into());
             }

--- a/src/input/maps/vim/normal/registers.rs
+++ b/src/input/maps/vim/normal/registers.rs
@@ -10,7 +10,7 @@ use crate::{
             vim::{tree::KeyTreeNode, VimKeymap},
             KeyHandlerContext, KeyResult,
         },
-        Key, KeyCode, KeyError, KeySource, KeymapContext,
+        Key, KeyCode, KeySource, KeymapContext,
     },
     vim_tree,
 };
@@ -44,7 +44,7 @@ pub fn mappings() -> KeyTreeNode {
             Ok(())
         },
 
-        "y" => operator |ctx, motion| {
+        "y" => operator ?change |ctx, motion| {
             let result = yank(&mut ctx, motion);
             ctx.state_mut().current_window_mut().cursor =
                 ctx.state().current_window().clamp_cursor(ctx.state().current_buffer(), motion.0);
@@ -128,6 +128,20 @@ mod tests {
             // Sanity check:
             let ctx = window("");
             ctx.feed_vim("yw").assert_visual_match("");
+        }
+
+        #[test]
+        fn yank_in_read_only() {
+            let mut ctx = window("Take my |love");
+            ctx.buffer
+                .set_source(crate::editing::source::BufferSource::Log);
+            let (_, mut state) = ctx.feed_vim_for_state("\"ayw");
+            let contents = state
+                .registers
+                .by_name('a')
+                .read()
+                .expect("Register should have contents set");
+            assert_eq!(contents, "love");
         }
 
         #[test]

--- a/src/input/maps/vim/util.rs
+++ b/src/input/maps/vim/util.rs
@@ -1,0 +1,11 @@
+use crate::input::{
+    maps::{KeyHandlerContext, KeyResult},
+    BoxableKeymap, KeymapContext,
+};
+
+pub fn verify_can_edit<T: BoxableKeymap>(context: &KeyHandlerContext<T>) -> KeyResult {
+    if context.state().current_buffer().is_read_only() {
+        return Err(crate::input::KeyError::ReadOnlyBuffer);
+    }
+    Ok(())
+}


### PR DESCRIPTION
Fixes #87

- Support yank in read-only buffers
- Unify and add more editability checks
