### PR TITLE
Support passing a string as the map target for set_keymap

### DIFF
--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -54,7 +54,11 @@ impl IaidoCore {
         };
 
         match mapping {
-            Either::A(_keys) => todo!(),
+            Either::A(to_keys) => {
+                context
+                    .keymap
+                    .remap_keys(mode, keys.into_keys(), to_keys.into_keys())
+            }
             Either::B(f) => {
                 context.keymap.remap_keys_user_fn(
                     mode,

--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -7,7 +7,7 @@ use crate::{
         maps::{KeyResult, UserKeyHandler},
         KeymapContext, RemapMode,
     },
-    script::fns::ScriptingFnRef,
+    script::{fns::ScriptingFnRef, poly::Either},
 };
 
 use super::{current::CurrentObjects, Api, Fns};
@@ -45,16 +45,24 @@ impl IaidoCore {
         context: &mut CommandHandlerContext,
         mode: String,
         keys: String,
-        f: ScriptingFnRef,
+        mapping: Either<String, ScriptingFnRef>,
     ) {
         let mode = match mode.as_str() {
             "n" => RemapMode::VimNormal,
             "i" => RemapMode::VimInsert,
             _ => RemapMode::User(mode),
         };
-        context
-            .keymap
-            .remap_keys_user_fn(mode, keys.into_keys(), create_user_keyhandler(f));
+
+        match mapping {
+            Either::A(_keys) => todo!(),
+            Either::B(f) => {
+                context.keymap.remap_keys_user_fn(
+                    mode,
+                    keys.into_keys(),
+                    create_user_keyhandler(f),
+                );
+            }
+        }
     }
 }
 

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,6 +1,7 @@
 mod api;
 mod bindings;
 mod fns;
+mod poly;
 
 #[cfg(feature = "python")]
 mod python;

--- a/src/script/poly.rs
+++ b/src/script/poly.rs
@@ -6,11 +6,3 @@ pub enum Either<A, B> {
     A(A),
     B(B),
 }
-
-#[allow(dead_code)]
-#[derive(Clone, Debug)]
-pub enum PickOfThree<A, B, C> {
-    A(A),
-    B(B),
-    C(C),
-}

--- a/src/script/poly.rs
+++ b/src/script/poly.rs
@@ -1,0 +1,16 @@
+//! Polymorphic script fn parameter types
+
+#[allow(dead_code)] // Ignore unused if scripting is disabled
+#[derive(Clone, Debug)]
+pub enum Either<A, B> {
+    A(A),
+    B(B),
+}
+
+#[allow(dead_code)]
+#[derive(Clone, Debug)]
+pub enum PickOfThree<A, B, C> {
+    A(A),
+    B(B),
+    C(C),
+}


### PR DESCRIPTION
More specifically, this provides an "Either" enum that lets you accept one of two types for a scripting API parameter.

- WIP: Prepare support for "either"-typed fn params
- Support remapping keys to other keys
