### PR TITLE
Add support for aliases to functions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 #  - python w/ default macOS linker: ~3.5s
 #  -                  python w/ zld: ~2.6s
 #  -            no languages w/ zld: ~1.4s
-default = ["python"]
+default = []
 
 python = ["rustpython-common", "rustpython-vm", "apigen/python"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 #  - python w/ default macOS linker: ~3.5s
 #  -                  python w/ zld: ~2.6s
 #  -            no languages w/ zld: ~1.4s
-default = []
+default = ["python"]
 
 python = ["rustpython-common", "rustpython-vm", "apigen/python"]
 

--- a/src/game/processing/manager.rs
+++ b/src/game/processing/manager.rs
@@ -56,14 +56,13 @@ impl<T: TextProcessor> TextProcessorManager<T> {
             self.processors.remove(&id);
         }
 
-        if !any_processed {
-            Ok(ProcessedText::Unprocessed(to_process.take().unwrap()))
+        Ok(if !any_processed {
+            ProcessedText::Unprocessed(to_process.take().unwrap())
+        } else if let Some(text) = to_process.take() {
+            ProcessedText::Processed(text, ProcessedTextFlags::NONE)
         } else {
-            Ok(ProcessedText::Processed(
-                to_process.take().unwrap(),
-                ProcessedTextFlags::NONE,
-            ))
-        }
+            ProcessedText::Removed(ProcessedTextFlags::NONE)
+        })
     }
 }
 

--- a/src/game/processing/matcher.rs
+++ b/src/game/processing/matcher.rs
@@ -147,7 +147,7 @@ fn simple_matcher_to_pattern(input: &str) -> String {
 pub struct Match {
     pub start: usize,
     pub end: usize,
-    groups: HashMap<String, TextLine>,
+    pub groups: HashMap<String, TextLine>,
 }
 
 impl Match {

--- a/src/script/api/buffer.rs
+++ b/src/script/api/buffer.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     editing::Id,
     input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext},
-    script::{fns::ScriptingFnRef, poly::Either, ScriptingManager},
+    script::{args::FnArgs, fns::ScriptingFnRef, poly::Either, ScriptingManager},
 };
 
 use super::{Api, Fns};
@@ -68,7 +68,7 @@ fn create_user_processor(
     Box::new(move |groups| match scripting.try_lock() {
         Ok(scripting) => {
             // FIXME: TODO: Figure out how to pass in a map and get out a string
-            let result = scripting.invoke(f)?;
+            let result = scripting.invoke(f, FnArgs::Map(groups))?;
             Ok(None)
         }
 

--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -7,7 +7,7 @@ use crate::{
         maps::{KeyResult, UserKeyHandler},
         KeymapContext, RemapMode,
     },
-    script::{fns::ScriptingFnRef, poly::Either},
+    script::{args::FnArgs, fns::ScriptingFnRef, poly::Either},
 };
 
 use super::{current::CurrentObjects, Api, Fns};
@@ -84,7 +84,7 @@ fn create_user_keyhandler(f: ScriptingFnRef) -> Box<UserKeyHandler> {
             .start(move |_| async move {
                 match scripting.try_lock() {
                     Ok(scripting) => {
-                        scripting.invoke(f)?;
+                        scripting.invoke(f, FnArgs::None)?;
                         Ok(())
                     }
                     Err(_) => Err(io::ErrorKind::WouldBlock.into()),

--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -27,7 +27,7 @@ impl IaidoCore {
 
     #[property]
     pub fn current(&self) -> CurrentObjects {
-        CurrentObjects::new(self.api.clone())
+        CurrentObjects::new(self.api.clone(), self.fns.clone())
     }
 
     #[rpc]

--- a/src/script/api/current.rs
+++ b/src/script/api/current.rs
@@ -6,18 +6,19 @@ use crate::{
 };
 
 use super::{
-    buffer::BufferApiObject, connection::ConnectionApiObject, window::WindowApiObject, Api,
+    buffer::BufferApiObject, connection::ConnectionApiObject, window::WindowApiObject, Api, Fns,
 };
 
 #[apigen::ns]
 pub struct CurrentObjects {
     api: Api,
+    fns: Fns,
 }
 
 #[apigen::ns_impl]
 impl CurrentObjects {
-    pub fn new(api: Api) -> Self {
-        Self { api }
+    pub fn new(api: Api, fns: Fns) -> Self {
+        Self { api, fns }
     }
 
     #[rpc]
@@ -27,7 +28,7 @@ impl CurrentObjects {
 
     #[property]
     pub fn buffer(&self) -> BufferApiObject {
-        BufferApiObject::new(self.api.clone(), self.buffer_id())
+        BufferApiObject::new(self.api.clone(), self.fns.clone(), self.buffer_id())
     }
 
     #[rpc]
@@ -65,7 +66,7 @@ impl CurrentObjects {
 
     #[property]
     pub fn window(&self) -> WindowApiObject {
-        WindowApiObject::new(self.api.clone(), self.window_id())
+        WindowApiObject::new(self.api.clone(), self.fns.clone(), self.window_id())
     }
 }
 

--- a/src/script/api/window.rs
+++ b/src/script/api/window.rs
@@ -5,24 +5,25 @@ use crate::{
     input::{commands::CommandHandlerContext, KeymapContext},
 };
 
-use super::{buffer::BufferApiObject, Api};
+use super::{buffer::BufferApiObject, Api, Fns};
 
 #[apigen::ns]
 pub struct WindowApiObject {
     api: Api,
+    fns: Fns,
     id: Id,
 }
 
 #[apigen::ns_impl]
 impl WindowApiObject {
-    pub fn new(api: Api, id: Id) -> Self {
-        Self { api, id }
+    pub fn new(api: Api, fns: Fns, id: Id) -> Self {
+        Self { api, fns, id }
     }
 
     #[property]
     pub fn buffer(&self) -> Option<BufferApiObject> {
         if let Some(id) = self.buffer_id() {
-            Some(BufferApiObject::new(self.api.clone(), id))
+            Some(BufferApiObject::new(self.api.clone(), self.fns.clone(), id))
         } else {
             None
         }

--- a/src/script/args.rs
+++ b/src/script/args.rs
@@ -1,0 +1,6 @@
+use std::collections::HashMap;
+
+pub enum FnArgs {
+    None,
+    Map(HashMap<String, String>),
+}

--- a/src/script/args.rs
+++ b/src/script/args.rs
@@ -4,3 +4,11 @@ pub enum FnArgs {
     None,
     Map(HashMap<String, String>),
 }
+
+pub trait FnReturnable {
+    fn is_string(&self) -> bool;
+
+    fn to_string(&self) -> Option<String>;
+}
+
+pub type FnReturnValue = Option<Box<dyn FnReturnable>>;

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -1,4 +1,5 @@
 mod api;
+mod args;
 mod bindings;
 mod fns;
 mod poly;
@@ -16,11 +17,11 @@ use crate::{
 };
 pub use api::ApiManagerRpc;
 
-use self::{api::ApiManagerDelegate, fns::ScriptingFnRef};
+use self::{api::ApiManagerDelegate, args::FnArgs, fns::ScriptingFnRef};
 
 pub trait ScriptingRuntime {
     fn load(&mut self, path: PathBuf) -> JobResult;
-    fn invoke(&mut self, f: ScriptingFnRef) -> JobResult;
+    fn invoke(&mut self, f: ScriptingFnRef, args: FnArgs) -> JobResult;
 }
 
 pub trait ScriptingRuntimeFactory {
@@ -132,10 +133,10 @@ impl ScriptingManager {
         Ok(id)
     }
 
-    pub fn invoke(&self, f: ScriptingFnRef) -> JobResult {
+    pub fn invoke(&self, f: ScriptingFnRef, args: FnArgs) -> JobResult {
         let mut runtimes = self.runtimes.borrow_mut();
         if let Some(runtime) = runtimes.get_mut(&f.runtime) {
-            runtime.invoke(f)
+            runtime.invoke(f, args)
         } else {
             // maybe panic?
             Err(JobError::Script("No such runtime".to_string()))

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -17,11 +17,15 @@ use crate::{
 };
 pub use api::ApiManagerRpc;
 
-use self::{api::ApiManagerDelegate, args::FnArgs, fns::ScriptingFnRef};
+use self::{
+    api::ApiManagerDelegate,
+    args::{FnArgs, FnReturnValue},
+    fns::ScriptingFnRef,
+};
 
 pub trait ScriptingRuntime {
     fn load(&mut self, path: PathBuf) -> JobResult;
-    fn invoke(&mut self, f: ScriptingFnRef, args: FnArgs) -> JobResult;
+    fn invoke(&mut self, f: ScriptingFnRef, args: FnArgs) -> JobResult<FnReturnValue>;
 }
 
 pub trait ScriptingRuntimeFactory {
@@ -133,7 +137,7 @@ impl ScriptingManager {
         Ok(id)
     }
 
-    pub fn invoke(&self, f: ScriptingFnRef, args: FnArgs) -> JobResult {
+    pub fn invoke(&self, f: ScriptingFnRef, args: FnArgs) -> JobResult<FnReturnValue> {
         let mut runtimes = self.runtimes.borrow_mut();
         if let Some(runtime) = runtimes.get_mut(&f.runtime) {
             runtime.invoke(f, args)

--- a/src/script/python/impls.rs
+++ b/src/script/python/impls.rs
@@ -1,0 +1,23 @@
+use rustpython_vm::{
+    function::{FuncArgs, IntoFuncArgs},
+    pyobject::{IntoPyObject, ItemProtocol},
+};
+
+use crate::script::args::FnArgs;
+
+impl IntoFuncArgs for FnArgs {
+    fn into_args(self, vm: &rustpython_vm::VirtualMachine) -> FuncArgs {
+        match self {
+            FnArgs::None => ().into(),
+            FnArgs::Map(m) => {
+                let dict = vm.ctx.new_dict();
+                for (k, v) in m {
+                    dict.set_item(vm.ctx.new_str(k), vm.ctx.new_str(v), vm)
+                        .expect("Unable to store entry in dict");
+                }
+                let obj = dict.into_pyobject(vm);
+                vec![obj].into()
+            }
+        }
+    }
+}

--- a/src/script/python/impls.rs
+++ b/src/script/python/impls.rs
@@ -1,9 +1,10 @@
 use rustpython_vm::{
+    builtins::PyStr,
     function::{FuncArgs, IntoFuncArgs},
-    pyobject::{IntoPyObject, ItemProtocol},
+    pyobject::{IntoPyObject, ItemProtocol, PyObjectRef},
 };
 
-use crate::script::args::FnArgs;
+use crate::script::args::{FnArgs, FnReturnable};
 
 impl IntoFuncArgs for FnArgs {
     fn into_args(self, vm: &rustpython_vm::VirtualMachine) -> FuncArgs {
@@ -19,5 +20,17 @@ impl IntoFuncArgs for FnArgs {
                 vec![obj].into()
             }
         }
+    }
+}
+
+pub struct PyFnReturnable(pub PyObjectRef);
+
+impl FnReturnable for PyFnReturnable {
+    fn is_string(&self) -> bool {
+        self.0.payload_is::<PyStr>()
+    }
+
+    fn to_string(&self) -> Option<String> {
+        self.0.downcast_ref::<PyStr>().map(|s| s.to_string())
     }
 }

--- a/src/script/python/mod.rs
+++ b/src/script/python/mod.rs
@@ -1,6 +1,5 @@
 #![cfg(feature = "python")]
 
-use rustpython_vm::pyobject::PyObjectRef;
 use std::{
     path::PathBuf,
     sync::{Arc, Mutex},
@@ -10,8 +9,7 @@ use rustpython_vm as vm;
 use vm::{
     builtins::PyNone,
     exceptions::PyBaseExceptionRef,
-    function::IntoFuncArgs,
-    pyobject::{ItemProtocol, PyResult, TryFromObject},
+    pyobject::{ItemProtocol, PyResult},
 };
 
 use crate::{
@@ -86,26 +84,6 @@ impl PythonScriptingRuntime {
     fn format_exception(&mut self, e: PyBaseExceptionRef) -> String {
         self.with_vm(|vm| PythonScriptingRuntime::format_exception_vm(vm, e))
     }
-
-    fn invoke_dyn<T: IntoFuncArgs, R: TryFromObject>(
-        &self,
-        fn_ref: ScriptingFnRef,
-        args: T,
-    ) -> JobResult<R> {
-        let fns = self.fns.clone();
-        self.with_vm(move |vm| {
-            let lock = fns.lock().unwrap();
-            let native = lock.get(&fn_ref);
-            let f = match native {
-                NativeFn::Py(ref f) => f,
-                _ => panic!("Received non-py Fn ref"),
-            };
-
-            let py_result = unwrap_error(vm, vm.invoke(&f, args))?;
-            let result = unwrap_error(vm, R::try_from_object(vm, py_result))?;
-            Ok(result)
-        })
-    }
 }
 
 impl ScriptingRuntime for PythonScriptingRuntime {
@@ -146,12 +124,23 @@ impl ScriptingRuntime for PythonScriptingRuntime {
     }
 
     fn invoke(&mut self, fn_ref: ScriptingFnRef, args: FnArgs) -> JobResult<FnReturnValue> {
-        let value: PyObjectRef = self.invoke_dyn(fn_ref, args)?;
-        if value.payload_is::<PyNone>() {
-            Ok(None)
-        } else {
-            Ok(Some(Box::new(PyFnReturnable(value))))
-        }
+        let fns = self.fns.clone();
+        self.with_vm(move |vm| {
+            let lock = fns.lock().unwrap();
+            let native = lock.get(&fn_ref);
+            let f = match native {
+                NativeFn::Py(ref f) => f,
+                _ => panic!("Received non-py Fn ref"),
+            };
+
+            let py_result = unwrap_error(vm, vm.invoke(&f, args))?;
+            if py_result.payload_is::<PyNone>() {
+                Ok(None)
+            } else {
+                let result: FnReturnValue = Some(Box::new(PyFnReturnable(py_result)));
+                Ok(result)
+            }
+        })
     }
 }
 


### PR DESCRIPTION
Functional aliases are provided a map containing the same params that would be accessible to a replacement string, and are expected to return a String value that will be sent. This lays some foundational support for passing values into scripting runtimes and receiving values back from them!

- WIP: Experiment with supporting fns for aliases
- Support passing dictionaries into script-provided fns
- Support unpacking the values returned from scripting!
