### PR TITLE
Add iaido.buf_set_keymap scripting fn

### DIFF
--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -62,7 +62,7 @@ pub type KeyHandler<T> = dyn Fn(KeyHandlerContext<'_, T>) -> KeyResult;
 pub type UserKeyHandler = dyn Fn(CommandHandlerContext<'_>) -> KeyResult;
 
 pub fn user_key_handler(keys: Vec<Key>, config: KeymapConfig) -> Box<UserKeyHandler> {
-    Box::new(move |ctx| {
+    Box::new(move |mut ctx| {
         ctx.feed_keys(keys.clone(), config)?;
         Ok(())
     })

--- a/src/input/maps/mod.rs
+++ b/src/input/maps/mod.rs
@@ -61,6 +61,13 @@ pub type KeyResult<T = ()> = Result<T, KeyError>;
 pub type KeyHandler<T> = dyn Fn(KeyHandlerContext<'_, T>) -> KeyResult;
 pub type UserKeyHandler = dyn Fn(CommandHandlerContext<'_>) -> KeyResult;
 
+pub fn user_key_handler(keys: Vec<Key>, config: KeymapConfig) -> Box<UserKeyHandler> {
+    Box::new(move |ctx| {
+        ctx.feed_keys(keys.clone(), config)?;
+        Ok(())
+    })
+}
+
 /// Syntactic sugar for declaring a key handler
 #[macro_export]
 macro_rules! key_handler {

--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -86,7 +86,7 @@ fn keyhandler(
     config: KeymapConfig,
 ) -> Box<UserKeyHandler> {
     match mapping {
-        Either::A(to_keys) => user_key_handler(to_keys, config),
+        Either::A(to_keys) => user_key_handler(to_keys.into_keys(), config),
         Either::B(f) => create_user_keyhandler(f),
     }
 }

--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -1,10 +1,11 @@
 use std::{fmt, io};
 
 use crate::{
+    editing::Id,
     input::{
         commands::{connection, CommandHandlerContext},
         keys::KeysParsable,
-        maps::{KeyResult, UserKeyHandler},
+        maps::{user_key_handler, KeyResult, UserKeyHandler},
         KeymapConfig, KeymapContext, RemapMode,
     },
     script::{args::FnArgs, fns::ScriptingFnRef, poly::Either},
@@ -48,32 +49,53 @@ impl IaidoCore {
     }
 
     #[rpc]
+    pub fn buf_set_keymap(
+        context: &mut CommandHandlerContext,
+        buffer_id: Id,
+        mode: String,
+        keys: String,
+        mapping: Either<String, ScriptingFnRef>,
+    ) {
+        // TODO Accept config from a param
+        context.keymap.buf_remap_keys_user_fn(
+            buffer_id,
+            parse_mode(mode),
+            keys.into_keys(),
+            keyhandler(mapping, KeymapConfig { allow_remap: true }),
+        )
+    }
+
+    #[rpc]
     pub fn set_keymap(
         context: &mut CommandHandlerContext,
         mode: String,
         keys: String,
         mapping: Either<String, ScriptingFnRef>,
     ) {
-        let mode = match mode.as_str() {
-            "n" => RemapMode::VimNormal,
-            "i" => RemapMode::VimInsert,
-            _ => RemapMode::User(mode),
-        };
+        // TODO Accept config from a param
+        context.keymap.remap_keys_user_fn(
+            parse_mode(mode),
+            keys.into_keys(),
+            keyhandler(mapping, KeymapConfig { allow_remap: true }),
+        )
+    }
+}
 
-        match mapping {
-            Either::A(to_keys) => {
-                context
-                    .keymap
-                    .remap_keys(mode, keys.into_keys(), to_keys.into_keys())
-            }
-            Either::B(f) => {
-                context.keymap.remap_keys_user_fn(
-                    mode,
-                    keys.into_keys(),
-                    create_user_keyhandler(f),
-                );
-            }
-        }
+fn keyhandler(
+    mapping: Either<String, ScriptingFnRef>,
+    config: KeymapConfig,
+) -> Box<UserKeyHandler> {
+    match mapping {
+        Either::A(to_keys) => user_key_handler(to_keys, config),
+        Either::B(f) => create_user_keyhandler(f),
+    }
+}
+
+fn parse_mode(mode: String) -> RemapMode {
+    match mode.as_str() {
+        "n" => RemapMode::VimNormal,
+        "i" => RemapMode::VimInsert,
+        _ => RemapMode::User(mode),
     }
 }
 


### PR DESCRIPTION
This also adds (but does not yet utilize) support for optional script API parameters, in preparation for supporting the optional "opts" map like nvim accepts (which will be in a separate PR because it's a bit complicated).