### PR TITLE
Support optional "opts" map for set_keymap fns

### DIFF
--- a/src/script/api/buffer.rs
+++ b/src/script/api/buffer.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     editing::Id,
     input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext},
-    script::{fns::ScriptingFnRef, poly::Either, ScriptingManager},
+    script::{args::FnArgs, fns::ScriptingFnRef, poly::Either, ScriptingManager},
 };
 
 use super::{connection::ConnectionApiObject, Api, Fns};
@@ -85,8 +85,8 @@ fn create_user_processor(
 ) -> Box<dyn Fn(HashMap<String, String>) -> KeyResult<Option<String>>> {
     Box::new(move |groups| match scripting.try_lock() {
         Ok(scripting) => match scripting.invoke(f, groups.into())? {
-            None => Ok(None),
-            Some(value) if value.is_string() => Ok(value.to_string()),
+            FnArgs::None => Ok(None),
+            FnArgs::String(s) => Ok(Some(s)),
             _ => Err(KeyError::InvalidInput(
                 "Returned an unexpected value".to_string(),
             )),

--- a/src/script/api/buffer.rs
+++ b/src/script/api/buffer.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     editing::Id,
     input::{commands::CommandHandlerContext, maps::KeyResult, KeyError, KeymapContext},
-    script::{args::FnArgs, fns::ScriptingFnRef, poly::Either, ScriptingManager},
+    script::{fns::ScriptingFnRef, poly::Either, ScriptingManager},
 };
 
 use super::{connection::ConnectionApiObject, Api, Fns};
@@ -84,7 +84,7 @@ fn create_user_processor(
     f: ScriptingFnRef,
 ) -> Box<dyn Fn(HashMap<String, String>) -> KeyResult<Option<String>>> {
     Box::new(move |groups| match scripting.try_lock() {
-        Ok(scripting) => match scripting.invoke(f, FnArgs::Map(groups))? {
+        Ok(scripting) => match scripting.invoke(f, groups.into())? {
             None => Ok(None),
             Some(value) if value.is_string() => Ok(value.to_string()),
             _ => Err(KeyError::InvalidInput(

--- a/src/script/args.rs
+++ b/src/script/args.rs
@@ -1,12 +1,28 @@
 use std::collections::HashMap;
 
+#[derive(Clone, Debug)]
 pub enum FnArgs {
     None,
-    Map(HashMap<String, String>),
+    Bool(bool),
+    String(String),
+    Map(HashMap<String, FnArgs>),
+}
+
+impl Into<FnArgs> for HashMap<String, String> {
+    fn into(self) -> FnArgs {
+        let mut m: HashMap<String, FnArgs> = Default::default();
+
+        for (k, v) in self {
+            m.insert(k, FnArgs::String(v));
+        }
+
+        FnArgs::Map(m)
+    }
 }
 
 pub trait FnReturnable {
     fn is_string(&self) -> bool;
+    fn is_truthy(&self) -> bool;
 
     fn to_string(&self) -> Option<String>;
 }

--- a/src/script/args.rs
+++ b/src/script/args.rs
@@ -19,12 +19,3 @@ impl Into<FnArgs> for HashMap<String, String> {
         FnArgs::Map(m)
     }
 }
-
-pub trait FnReturnable {
-    fn is_string(&self) -> bool;
-    fn is_truthy(&self) -> bool;
-
-    fn to_string(&self) -> Option<String>;
-}
-
-pub type FnReturnValue = Option<Box<dyn FnReturnable>>;

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -17,15 +17,11 @@ use crate::{
 };
 pub use api::ApiManagerRpc;
 
-use self::{
-    api::ApiManagerDelegate,
-    args::{FnArgs, FnReturnValue},
-    fns::ScriptingFnRef,
-};
+use self::{api::ApiManagerDelegate, args::FnArgs, fns::ScriptingFnRef};
 
 pub trait ScriptingRuntime {
     fn load(&mut self, path: PathBuf) -> JobResult;
-    fn invoke(&mut self, f: ScriptingFnRef, args: FnArgs) -> JobResult<FnReturnValue>;
+    fn invoke(&mut self, f: ScriptingFnRef, args: FnArgs) -> JobResult<FnArgs>;
 }
 
 pub trait ScriptingRuntimeFactory {
@@ -137,7 +133,7 @@ impl ScriptingManager {
         Ok(id)
     }
 
-    pub fn invoke(&self, f: ScriptingFnRef, args: FnArgs) -> JobResult<FnReturnValue> {
+    pub fn invoke(&self, f: ScriptingFnRef, args: FnArgs) -> JobResult<FnArgs> {
         let mut runtimes = self.runtimes.borrow_mut();
         if let Some(runtime) = runtimes.get_mut(&f.runtime) {
             runtime.invoke(f, args)

--- a/src/script/python/impls.rs
+++ b/src/script/python/impls.rs
@@ -1,25 +1,81 @@
+use std::{cmp::Ordering, collections::HashMap};
+
+use rustpython_common::borrow::BorrowValue;
 use rustpython_vm::{
-    builtins::PyStr,
+    builtins::{PyDict, PyInt, PyNone, PyStr},
     function::{FuncArgs, IntoFuncArgs},
-    pyobject::{IntoPyObject, ItemProtocol, PyObjectRef},
+    pyobject::{IdProtocol, IntoPyObject, ItemProtocol, PyObjectRef, TryFromObject},
 };
 
 use crate::script::args::{FnArgs, FnReturnable};
+
+impl IntoPyObject for FnArgs {
+    fn into_pyobject(self, vm: &rustpython_vm::VirtualMachine) -> PyObjectRef {
+        match self {
+            FnArgs::None => vm.ctx.none(),
+            FnArgs::Bool(b) => vm.ctx.new_bool(b),
+            FnArgs::String(s) => vm.ctx.new_str(s),
+            FnArgs::Map(m) => {
+                let dict = vm.ctx.new_dict();
+                for (k, v) in m {
+                    dict.set_item(vm.ctx.new_str(k), v.into_pyobject(vm), vm)
+                        .expect("Unable to store entry in dict");
+                }
+                dict.into_pyobject(vm)
+            }
+        }
+    }
+}
 
 impl IntoFuncArgs for FnArgs {
     fn into_args(self, vm: &rustpython_vm::VirtualMachine) -> FuncArgs {
         match self {
             FnArgs::None => ().into(),
-            FnArgs::Map(m) => {
-                let dict = vm.ctx.new_dict();
-                for (k, v) in m {
-                    dict.set_item(vm.ctx.new_str(k), vm.ctx.new_str(v), vm)
-                        .expect("Unable to store entry in dict");
+            other => vec![other.into_pyobject(vm)].into(),
+        }
+    }
+}
+
+fn into_string(obj: &PyObjectRef) -> Option<String> {
+    if let Some(s) = obj.downcast_ref::<PyStr>().map(|s| s.to_string()) {
+        return Some(s);
+    } else {
+        None
+    }
+}
+
+impl TryFromObject for FnArgs {
+    fn try_from_object(
+        vm: &rustpython_vm::VirtualMachine,
+        obj: PyObjectRef,
+    ) -> rustpython_vm::pyobject::PyResult<Self> {
+        if obj.payload_is::<PyNone>() {
+            return Ok(Self::None);
+        } else if obj.payload_is::<PyStr>() {
+            if let Some(s) = into_string(&obj) {
+                return Ok(Self::String(s));
+            }
+        } else if obj.payload_is::<PyDict>() {
+            if let Some(dict) = obj.downcast_ref::<PyDict>() {
+                let mut map: HashMap<String, FnArgs> = Default::default();
+                for (k, v) in dict.into_iter() {
+                    if let Some(k) = into_string(&k) {
+                        let v = Self::try_from_object(vm, v)?;
+                        map.insert(k, v);
+                    }
                 }
-                let obj = dict.into_pyobject(vm);
-                vec![obj].into()
+
+                return Ok(Self::Map(map));
             }
         }
+
+        // Fallback:
+        if obj.is(&vm.ctx.true_value) {
+            return Ok(Self::Bool(true));
+        } else if obj.is(&vm.ctx.false_value) {
+            return Ok(Self::Bool(false));
+        }
+        Ok(Self::None)
     }
 }
 
@@ -28,6 +84,16 @@ pub struct PyFnReturnable(pub PyObjectRef);
 impl FnReturnable for PyFnReturnable {
     fn is_string(&self) -> bool {
         self.0.payload_is::<PyStr>()
+    }
+
+    fn is_truthy(&self) -> bool {
+        if self.0.payload_is::<PyInt>() {
+            if let Some(as_int) = self.0.downcast_ref::<PyInt>() {
+                return as_int.borrow_value().cmp(&0u32.into()) != Ordering::Equal;
+            }
+        }
+
+        false
     }
 
     fn to_string(&self) -> Option<String> {

--- a/src/script/python/impls.rs
+++ b/src/script/python/impls.rs
@@ -1,13 +1,12 @@
-use std::{cmp::Ordering, collections::HashMap};
+use std::collections::HashMap;
 
-use rustpython_common::borrow::BorrowValue;
 use rustpython_vm::{
-    builtins::{PyDict, PyInt, PyNone, PyStr},
+    builtins::{PyDict, PyNone, PyStr},
     function::{FuncArgs, IntoFuncArgs},
     pyobject::{IdProtocol, IntoPyObject, ItemProtocol, PyObjectRef, TryFromObject},
 };
 
-use crate::script::args::{FnArgs, FnReturnable};
+use crate::script::args::FnArgs;
 
 impl IntoPyObject for FnArgs {
     fn into_pyobject(self, vm: &rustpython_vm::VirtualMachine) -> PyObjectRef {
@@ -76,27 +75,5 @@ impl TryFromObject for FnArgs {
             return Ok(Self::Bool(false));
         }
         Ok(Self::None)
-    }
-}
-
-pub struct PyFnReturnable(pub PyObjectRef);
-
-impl FnReturnable for PyFnReturnable {
-    fn is_string(&self) -> bool {
-        self.0.payload_is::<PyStr>()
-    }
-
-    fn is_truthy(&self) -> bool {
-        if self.0.payload_is::<PyInt>() {
-            if let Some(as_int) = self.0.downcast_ref::<PyInt>() {
-                return as_int.borrow_value().cmp(&0u32.into()) != Ordering::Equal;
-            }
-        }
-
-        false
-    }
-
-    fn to_string(&self) -> Option<String> {
-        self.0.downcast_ref::<PyStr>().map(|s| s.to_string())
     }
 }


### PR DESCRIPTION
Includes the necessary support for sending mixed-value HashMap values to
(and receiving them back from) scripts, and simplifies invoking scripting
fns by returning this same enum instead of the old boxed type.

- Add support for passing hashmaps with mixed values from scripts
- Remove FnReturnValue in favor of FnArgs
