### PR TITLE
Add :source and :reload commands

### DIFF
--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -162,7 +162,7 @@ where
             connect(&mut ctx, uri.to_string())?;
         }
         Some(CliInit::ScriptFile(path)) => {
-            ScriptingManager::load_scripts(app_keys, map, vec![path]);
+            ScriptingManager::load_script(app_keys, map, path);
         }
         None => {} // nop
     }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,7 +5,7 @@ use indoc::indoc;
 
 pub enum CliInit {
     Uri(String),
-    ScriptFile(String),
+    ScriptFile(PathBuf),
 }
 
 pub struct Args {
@@ -73,9 +73,7 @@ fn parse_target(target: &str, port: Option<&str>) -> Result<CliInit, clap::Error
         return Ok(CliInit::ScriptFile(
             path_buf
                 .canonicalize()
-                .expect("Unable to canonicalize path")
-                .to_string_lossy()
-                .to_string(),
+                .expect("Unable to canonicalize path"),
         ));
     }
 

--- a/src/editing/buffer/mod.rs
+++ b/src/editing/buffer/mod.rs
@@ -5,7 +5,7 @@ mod util;
 pub use memory::MemoryBuffer;
 pub use undoable::UndoableBuffer;
 
-use std::fmt;
+use std::{fmt, path::PathBuf};
 
 use crate::{
     connection::ReadValue,
@@ -124,6 +124,7 @@ impl Default for BufHidden {
 #[derive(Default)]
 pub struct BufferConfig {
     pub bufhidden: BufHidden,
+    pub loaded_script: Option<PathBuf>,
 }
 
 pub trait Buffer: HasId + Send + Sync {

--- a/src/game/engine.rs
+++ b/src/game/engine.rs
@@ -70,4 +70,10 @@ impl GameEngine {
             Err(e) => Err(e),
         }
     }
+
+    /// Reset any configured state on this Engine; relevant when re-loading
+    /// a script, for example, to clear previously-created state
+    pub fn reset(&mut self) {
+        self.aliases.clear();
+    }
 }

--- a/src/game/processing/manager.rs
+++ b/src/game/processing/manager.rs
@@ -17,6 +17,10 @@ impl<T: TextProcessor> TextProcessorManager<T> {
         }
     }
 
+    pub fn clear(&mut self) {
+        self.processors.clear();
+    }
+
     pub fn insert(&mut self, description: String, processor: T) -> Option<T> {
         self.processors.insert(description, processor)
     }

--- a/src/input/commands/mod.rs
+++ b/src/input/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod help;
 pub mod log;
 pub mod mapping;
 pub mod registry;
+pub mod script;
 pub mod window;
 
 mod helpers;
@@ -15,7 +16,7 @@ use std::time::Duration;
 use self::{
     colors::declare_colors, connection::declare_connection, core::declare_core, file::declare_file,
     help::declare_help, log::declare_log, mapping::declare_mapping, registry::CommandRegistry,
-    window::declare_window,
+    script::declare_script, window::declare_window,
 };
 use crate::delegate_keysource_with_map;
 
@@ -105,6 +106,7 @@ pub fn create_builtin_commands() -> CommandRegistry {
     declare_colors(&mut registry);
     declare_log(&mut registry);
     declare_mapping(&mut registry);
+    declare_script(&mut registry);
     declare_window(&mut registry);
 
     declare_connection(&mut registry);

--- a/src/input/commands/script.rs
+++ b/src/input/commands/script.rs
@@ -35,13 +35,25 @@ fn reload_buffer_source(context: &mut CommandHandlerContext) -> KeyResult {
     {
         source_path(context, path)?;
     } else {
+        // TODO Probably, check for an associated buffer via Connections
+        // to handle running this while eg focusing the input buffer
         context.state_mut().echom("No script loaded in this bufer");
     }
     Ok(())
 }
 
 fn source_path(context: &mut CommandHandlerContext, file_path: PathBuf) -> KeyResult {
-    // TODO Clear config on any connection
+    let buffer_id = context.state().current_buffer().id();
+    if let Some(conn) = context
+        .state_mut()
+        .connections
+        .as_mut()
+        .and_then(|conns| conns.by_buffer_id(buffer_id))
+    {
+        // Clear config on any associated connection
+        conn.game.reset();
+    }
+
     let path_str = file_path.to_string_lossy().to_string();
     ScriptingManager::load_script(&mut context.context, &mut context.keymap, file_path);
     context.state_mut().echom(format!("Sourced {}", path_str));

--- a/src/input/commands/script.rs
+++ b/src/input/commands/script.rs
@@ -6,21 +6,44 @@ use std::path::PathBuf;
 
 use command_decl::declare_commands;
 
-use crate::{input::maps::KeyResult, script::ScriptingManager};
+use crate::{
+    input::{maps::KeyResult, KeymapContext},
+    script::ScriptingManager,
+};
 
 use super::CommandHandlerContext;
 
 declare_commands!(declare_script {
+    /// Re-load the most-recently :sourced a script file for the current buffer
+    pub fn reload(context) {
+        reload_buffer_source(context)
+    },
+
     /// Load a script file
     pub fn source(context, file_path: PathBuf) {
         source_path(context, file_path)
     },
 });
 
+fn reload_buffer_source(context: &mut CommandHandlerContext) -> KeyResult {
+    if let Some(path) = context
+        .state_mut()
+        .current_buffer_mut()
+        .config_mut()
+        .loaded_script
+        .take()
+    {
+        source_path(context, path)?;
+    } else {
+        context.state_mut().echom("No script loaded in this bufer");
+    }
+    Ok(())
+}
+
 fn source_path(context: &mut CommandHandlerContext, file_path: PathBuf) -> KeyResult {
-    // TODO Stash file_path somewhere so we can :reload
-
+    // TODO Clear config on any connection
+    let path_str = file_path.to_string_lossy().to_string();
     ScriptingManager::load_script(&mut context.context, &mut context.keymap, file_path);
-
+    context.state_mut().echom(format!("Sourced {}", path_str));
     Ok(())
 }

--- a/src/input/commands/script.rs
+++ b/src/input/commands/script.rs
@@ -20,11 +20,7 @@ declare_commands!(declare_script {
 fn source_path(context: &mut CommandHandlerContext, file_path: PathBuf) -> KeyResult {
     // TODO Stash file_path somewhere so we can :reload
 
-    ScriptingManager::load_scripts(
-        &mut context.context,
-        &mut context.keymap,
-        vec![file_path.to_string_lossy().to_string()],
-    );
+    ScriptingManager::load_script(&mut context.context, &mut context.keymap, file_path);
 
     Ok(())
 }

--- a/src/input/commands/script.rs
+++ b/src/input/commands/script.rs
@@ -1,0 +1,30 @@
+/*!
+ * Script-related commands
+ */
+
+use std::path::PathBuf;
+
+use command_decl::declare_commands;
+
+use crate::{input::maps::KeyResult, script::ScriptingManager};
+
+use super::CommandHandlerContext;
+
+declare_commands!(declare_script {
+    /// Load a script file
+    pub fn source(context, file_path: PathBuf) {
+        source_path(context, file_path)
+    },
+});
+
+fn source_path(context: &mut CommandHandlerContext, file_path: PathBuf) -> KeyResult {
+    // TODO Stash file_path somewhere so we can :reload
+
+    ScriptingManager::load_scripts(
+        &mut context.context,
+        &mut context.keymap,
+        vec![file_path.to_string_lossy().to_string()],
+    );
+
+    Ok(())
+}

--- a/src/script/bindings.rs
+++ b/src/script/bindings.rs
@@ -1,6 +1,6 @@
 /*! Utils for implementing scripting language bindings */
 
-use std::{fs, io, path::PathBuf};
+use std::{fs, io, path::Path};
 
 pub struct ScriptFile {
     pub path: String,
@@ -10,7 +10,7 @@ pub struct ScriptFile {
 // Allow dead code in case all languages are disabled:
 #[allow(dead_code)]
 impl ScriptFile {
-    pub fn read_from(path: PathBuf) -> io::Result<Self> {
+    pub fn read_from(path: &Path) -> io::Result<Self> {
         let code = fs::read_to_string(&path)?;
         let path_string = path.to_string_lossy().to_string();
         return Ok(Self {

--- a/src/script/mod.rs
+++ b/src/script/mod.rs
@@ -71,6 +71,11 @@ impl ScriptingManager {
         map: &mut KM,
         script: PathBuf,
     ) {
+        context
+            .state_mut()
+            .current_buffer_mut()
+            .config_mut()
+            .loaded_script = Some(script.clone());
         Self::load_scripts(context, map, vec![script])
     }
 

--- a/src/script/python/mod.rs
+++ b/src/script/python/mod.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "python")]
 
 use std::{
-    path::PathBuf,
+    path::Path,
     sync::{Arc, Mutex},
 };
 
@@ -86,8 +86,8 @@ impl PythonScriptingRuntime {
 }
 
 impl ScriptingRuntime for PythonScriptingRuntime {
-    fn load(&mut self, path: PathBuf) -> JobResult {
-        let script = ScriptFile::read_from(path.clone())?;
+    fn load(&mut self, path: &Path) -> JobResult {
+        let script = ScriptFile::read_from(path)?;
 
         let result: PyResult<()> = self.with_vm(move |runtime| {
             let scope = runtime.new_scope_with_builtins();
@@ -144,7 +144,7 @@ impl ScriptingRuntimeFactory for PythonScriptingRuntimeFactory {
         Box::new(PythonScriptingRuntime::new(id, app))
     }
 
-    fn handles_file(&self, path: &std::path::PathBuf) -> bool {
+    fn handles_file(&self, path: &std::path::Path) -> bool {
         if let Some(ext) = path.extension() {
             return ext == "py";
         }


### PR DESCRIPTION
As we had in Judo, but much cleaner since Aliases, etc. are naturally isolated per-connection.

- Add rough :source command implementation
- Refactor to use &Path instead of PathBuf
- Remove unnecessary PathBuf -> String conversions; just use PathBuf
- Add :reload command for quickly re-source'ing the buffer's script
- Clear configured aliases before :source
