### PR TITLE
Support entering user modes

### DIFF
--- a/src/app/widgets.rs
+++ b/src/app/widgets.rs
@@ -1,5 +1,6 @@
 use crate::editing::text::TextLine;
 
+#[derive(Clone, Debug)]
 pub enum Widget {
     Space,
     Spread(Vec<Widget>),

--- a/src/editing/motion/mod.rs
+++ b/src/editing/motion/mod.rs
@@ -223,6 +223,10 @@ pub mod tests {
     pub struct TestBoxableKeymap;
 
     impl BoxableKeymap for TestBoxableKeymap {
+        fn enter_user_mode(&mut self, _mode: String) -> bool {
+            todo!()
+        }
+
         fn remap_keys(
             &mut self,
             _mode: crate::input::RemapMode,

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -404,6 +404,27 @@ impl Keymap for VimKeymap {
 }
 
 impl BoxableKeymap for VimKeymap {
+    fn enter_user_mode(&mut self, mode_name: String) -> bool {
+        let remap_mode = RemapMode::User(mode_name.clone());
+        if let Some(mappings) = self.user_maps.get(&remap_mode) {
+            let mode_id = mode_name.clone();
+            let mut mode = VimMode::new(
+                mode_name,
+                crate::vim_tree! {
+                    "<esc>" => move |?mut ctx| {
+                        ctx.keymap.pop_mode(&mode_id);
+                        Ok(())
+                    },
+                } + mappings.clone(),
+            );
+            mode.shows_keys = true;
+            self.push_mode(mode);
+            return true;
+        }
+
+        return false;
+    }
+
     fn process_keys(&mut self, context: &mut KeymapContextWithKeys<MemoryKeySource>) -> KeyResult {
         self.process(context)
     }
@@ -451,6 +472,7 @@ impl BoxableKeymap for VimKeymap {
             }),
         );
     }
+
     fn as_any_mut(&mut self) -> &mut dyn Any {
         self
     }

--- a/src/input/maps/vim/mode_stack.rs
+++ b/src/input/maps/vim/mode_stack.rs
@@ -47,27 +47,4 @@ impl VimModeStack {
             None
         }
     }
-
-    /// Returns the Mode if it should no longer be on the stack,
-    /// else None if it was accepted
-    pub fn return_top(&mut self, mode: VimMode) -> Option<VimMode> {
-        if self.stack.contains(&mode.id) {
-            self.modes.insert(mode.id.clone(), mode);
-            None
-        } else {
-            Some(mode)
-        }
-    }
-
-    pub fn take_top(&mut self) -> Option<VimMode> {
-        if let Some(id) = self.stack.last() {
-            Some(
-                self.modes
-                    .remove(id)
-                    .expect(&format!("Top of stack mode {} not found", id)),
-            )
-        } else {
-            None
-        }
-    }
 }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -204,6 +204,7 @@ pub trait Remappable<T: Keymap + BoxableKeymap>: BoxableKeymap {
 }
 
 pub trait BoxableKeymap {
+    fn enter_user_mode(&mut self, mode: String) -> bool;
     fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
     fn remap_keys_user_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
     fn buf_remap_keys_user_fn(
@@ -220,6 +221,7 @@ pub trait BoxableKeymap {
 impl BoxableKeymap for Box<&mut dyn BoxableKeymap> {
     delegate! {
         to (**self) {
+            fn enter_user_mode(&mut self, mode: String) -> bool;
             fn remap_keys(&mut self, mode: RemapMode, from: Vec<Key>, to: Vec<Key>);
             fn remap_keys_user_fn(&mut self, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);
             fn buf_remap_keys_user_fn(&mut self, buf_id: Id, mode: RemapMode, keys: Vec<Key>, handler: Box<UserKeyHandler>);

--- a/src/script/api/core.rs
+++ b/src/script/api/core.rs
@@ -6,7 +6,7 @@ use crate::{
         commands::{connection, CommandHandlerContext},
         keys::KeysParsable,
         maps::{user_key_handler, KeyResult, UserKeyHandler},
-        KeymapConfig, KeymapContext, RemapMode,
+        KeyError, KeymapConfig, KeymapContext, RemapMode,
     },
     script::{args::FnArgs, fns::ScriptingFnRef, poly::Either},
 };
@@ -39,6 +39,15 @@ impl IaidoCore {
     #[rpc]
     pub fn echo(context: &mut CommandHandlerContext, text: String) {
         context.state_mut().echom(text);
+    }
+
+    #[rpc]
+    pub fn enter_mode(context: &mut CommandHandlerContext, mode: String) -> KeyResult {
+        if context.keymap.enter_user_mode(mode.clone()) {
+            Ok(())
+        } else {
+            Err(KeyError::InvalidInput(format!("No such mode: `{}`", mode)))
+        }
     }
 
     #[rpc]


### PR DESCRIPTION
Somewhat big change here is that we now clone modes from the stack instead of removing and restoring them; this simplifies the logic quite a bit, and handles re-entrant `process()` calls in stack-bound modes (for example, inputting a mapping that is a simple remap)

- Add initial iaido.enter_mode script method to active user modes
- Add test demonstrating user mode error
- Just go ahead and clone the stack mode to fix "mode not found"
- Render a usermode indicator
