### PR TITLE
Implement input history, accessible in cmdline mode via `qi`

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -277,6 +277,26 @@ impl AppState {
         window.scrolled_lines = 0;
         window.scroll_offset = 0;
     }
+
+    pub fn conn_input_buffer_id(&self, conn_id: Id) -> Option<Id> {
+        if let Some((Some(output_buffer_id), buffer_ids)) = self
+            .connections
+            .as_ref()
+            .map(|conns| (conns.id_to_buffer(conn_id), conns.id_to_buffers(conn_id)))
+        {
+            // NOTE: There should be two buffer IDs per connection: the input
+            // and the output. We have a direct mapping to the output buffer,
+            // but don't frequently need to find the input buffer (yet) so
+            // this is a somewhat straightforward way to look it up
+            buffer_ids
+                .into_iter()
+                .filter(|id| id != &output_buffer_id)
+                .next()
+                .to_owned()
+        } else {
+            None
+        }
+    }
 }
 
 impl Default for AppState {

--- a/src/app/winsbuf.rs
+++ b/src/app/winsbuf.rs
@@ -33,6 +33,10 @@ impl<'a> WinsBuf<'a> {
         });
     }
 
+    pub fn clear(&mut self) {
+        self.buffer.clear();
+    }
+
     #[inline]
     fn adjusting_cursor(&mut self, action: impl FnOnce(&mut WinsBuf)) {
         let lines_before = self.buffer.lines_count();

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -48,6 +48,19 @@ impl Connections {
         self.connection_to_buffer.get(&id).cloned()
     }
 
+    pub fn id_to_buffers(&self, id: Id) -> Vec<Id> {
+        self.buffer_to_connection
+            .iter()
+            .filter_map(|(buff_id, conn_id)| {
+                if *conn_id == id {
+                    Some(buff_id.to_owned())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     pub fn by_buffer_id(&mut self, buffer_id: Id) -> Option<&mut GameConnection> {
         if let Some(conn_id) = self.buffer_to_id(buffer_id) {
             self.by_id_mut(conn_id)

--- a/src/editing/tabpage.rs
+++ b/src/editing/tabpage.rs
@@ -166,6 +166,18 @@ impl Tabpage {
         self.layout.by_id_mut(id).unwrap().focused = true;
     }
 
+    /// Returns the Id of the focused window, if the buffer was found
+    pub fn set_focus_to_buffer(&mut self, buffer_id: Id) -> Option<Id> {
+        let win_id =
+            if let Some(win_id) = self.windows_for_buffer(buffer_id).next().map(|win| win.id) {
+                win_id
+            } else {
+                return None;
+            };
+        self.set_focus(win_id);
+        Some(win_id)
+    }
+
     fn window_for_split(&mut self) -> &mut Box<Window> {
         self.layout
             .by_id_for_split(self.current)

--- a/src/input/commands/connection.rs
+++ b/src/input/commands/connection.rs
@@ -35,15 +35,7 @@ declare_commands!(declare_connection {
         }
 
         if let Some((id, url)) = get_associated_connection(context) {
-            let win_id = context
-                .state_mut()
-                .current_tab_mut()
-                .windows_for_buffer(id)
-                .next()
-                .map(|win| win.id);
-            if let Some(win_id) = win_id {
-                context.state_mut().current_tab_mut().set_focus(win_id);
-            }
+            context.state_mut().current_tab_mut().set_focus_to_buffer(id);
             connect(context, url)
         } else {
             Err(KeyError::InvalidInput("No associated connection for current buffer".to_string()))

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -27,7 +27,13 @@ pub fn send_current_input_buffer<T: BoxableKeymap>(mut ctx: KeyHandlerContext<T>
             return Err(KeyError::IO(io::ErrorKind::NotConnected.into()));
         };
 
-    send_string_to_buffer(&mut ctx, conn_buffer_id, to_send)
+    let result = send_string_to_buffer(&mut ctx, conn_buffer_id, to_send);
+
+    if result.is_ok() {
+        ctx.state_mut().current_buffer_mut().clear();
+    }
+
+    result
 }
 
 pub fn send_string_to_buffer<K: KeymapContext>(
@@ -45,7 +51,6 @@ pub fn send_string_to_buffer<K: KeymapContext>(
     }
 
     if sent {
-        ctx.state_mut().current_buffer_mut().clear();
         if let Some(mut output) = ctx.state_mut().winsbuf_by_id(conn_buffer_id) {
             output.append_value(ReadValue::Text(to_send.into()));
             output.append_value(ReadValue::Newline);

--- a/src/input/maps/vim/cmdline.rs
+++ b/src/input/maps/vim/cmdline.rs
@@ -70,14 +70,22 @@ fn cmdline_to_prompt(
                     .current_tab_mut()
                     .set_focus_to_buffer(input_buffer_id)
                     .is_some();
-                if let Some(mut winsbuf) = ctx.state_mut().winsbuf_by_id(input_buffer_id) {
-                    winsbuf.clear();
-                    winsbuf.append(cmd.into());
-                    found_window
-                } else {
-                    // No winsbuf; this *should not* be possible, but perhaps we got disconnected
-                    // or otherwise tore down the input UI while the cmdline window was open?
-                    false
+                match ctx.state_mut().winsbuf_by_id(input_buffer_id) {
+                    Some(mut winsbuf) if !cmd.is_empty() => {
+                        winsbuf.clear();
+                        winsbuf.append(cmd.into());
+                        found_window
+                    }
+
+                    _ => {
+                        // No winsbuf or nothing selected; it's unlikely that there's no winsbuf,
+                        // but perhaps we got disconnected or otherwise tore down the input UI
+                        // while the cmdline window was open?
+                        // If we selected nothing, we *probably* don't want to override whatever
+                        // might have been in the winsbuf before, and we *definitely* don't want to
+                        // send it
+                        false
+                    }
                 }
             } else {
                 // Couldn't find the input buffer

--- a/src/input/maps/vim/cmdline.rs
+++ b/src/input/maps/vim/cmdline.rs
@@ -1,0 +1,153 @@
+use tui::{
+    style::{Color, Style},
+    text::{Span, Spans},
+};
+
+use crate::{
+    editing::text::EditableLine,
+    input::{history::History, Key, KeyCode},
+};
+use crate::{
+    editing::{buffer::BufHidden, gutter::Gutter, source::BufferSource},
+    input::{
+        keys::KeysParsable,
+        maps::{KeyHandlerContext, KeyResult},
+        KeymapContext, RemapMode, Remappable,
+    },
+};
+
+use super::VimKeymap;
+
+fn cmdline_to_prompt(
+    mut ctx: KeyHandlerContext<VimKeymap>,
+    prompt_key: String,
+) -> KeyResult<KeyHandlerContext<VimKeymap>> {
+    let cmd = if let Some(cmd_spans) = ctx
+        .state()
+        .current_buffer()
+        .checked_get(ctx.state().current_window().cursor.line)
+    {
+        cmd_spans.to_string()
+    } else {
+        "".to_string()
+    };
+
+    // Release the buffer
+    let buffer_id = ctx.state().current_buffer().id();
+    ctx.state_mut().delete_buffer(buffer_id);
+
+    // Is this *too* hacky? Just feed each char as a key:
+    // Perhaps we should match on prompt_key and invoke eg `handle_command`,
+    // `handle_forward_search`, etc. directly...
+    ctx = ctx.feed_keys_noremap(prompt_key.into_keys())?;
+
+    let cmd_as_keys: Vec<Key> = cmd.chars().map(|ch| Key::from(KeyCode::Char(ch))).collect();
+    ctx = ctx.feed_keys_noremap(cmd_as_keys)?;
+    Ok(ctx)
+}
+
+fn cancel_cmdline(ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
+    cmdline_to_prompt(ctx, prompt_key)?;
+    Ok(())
+}
+
+fn submit_cmdline(ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
+    let ctx = cmdline_to_prompt(ctx, prompt_key)?;
+    ctx.feed_keys_noremap("<cr>".into_keys())?;
+    Ok(())
+}
+
+pub fn open_from_history(
+    ctx: &mut KeyHandlerContext<VimKeymap>,
+    history: &History<String>,
+    history_key: String,
+    prompt_key: String,
+) -> KeyResult<()> {
+    ctx.state_mut().clear_echo();
+
+    let win_id = ctx.state_mut().current_tab_mut().split_bottom();
+    let buffer = ctx.state_mut().buffers.create_mut();
+    let buf_id = buffer.id();
+    buffer.set_source(BufferSource::Cmdline);
+    buffer.config_mut().bufhidden = BufHidden::Delete;
+
+    let mut count = 0;
+    for entry in history.iter().rev() {
+        buffer.append_line(entry.to_string());
+        count += 1;
+    }
+
+    ctx.state_mut().current_tab_mut().set_focus(win_id);
+    ctx.state_mut().set_current_window_buffer(buf_id);
+
+    // Bind <cr> to submit the input
+    let normal_prompt_key = prompt_key.clone();
+    let insert_prompt_key = prompt_key.clone();
+    ctx.keymap.buf_remap_keys_fn(
+        buf_id,
+        RemapMode::VimNormal,
+        "<cr>".into_keys(),
+        Box::new(move |ctx| submit_cmdline(ctx, normal_prompt_key.to_string())),
+    );
+    ctx.keymap.buf_remap_keys_fn(
+        buf_id,
+        RemapMode::VimInsert,
+        "<cr>".into_keys(),
+        Box::new(move |ctx| submit_cmdline(ctx, insert_prompt_key.to_string())),
+    );
+
+    // Bind <ctrl-c> to cancel the mode
+    let normal_prompt_key = prompt_key.clone();
+    ctx.keymap.buf_remap_keys_fn(
+        buf_id,
+        RemapMode::VimNormal,
+        "<ctrl-c>".into_keys(),
+        Box::new(move |ctx| cancel_cmdline(ctx, normal_prompt_key.to_string())),
+    );
+    ctx.keymap.buf_remap_keys_fn(
+        buf_id,
+        RemapMode::VimInsert,
+        "<ctrl-c>".into_keys(),
+        Box::new(move |ctx| cancel_cmdline(ctx, prompt_key.to_string())),
+    );
+
+    let win = ctx.state_mut().current_tab_mut().by_id_mut(win_id).unwrap();
+
+    // TODO Resize to cmdwinheight
+
+    let non_line_prefix = vec![Span::styled("~", Style::default().fg(Color::DarkGray))];
+
+    let gutter_prefix = vec![Span::styled(
+        history_key,
+        Style::default().fg(Color::DarkGray),
+    )];
+
+    win.gutter = Some(Gutter {
+        width: 1,
+        get_content: Box::new(move |line| {
+            Spans(match line {
+                Some(_) => gutter_prefix.clone(),
+                None => non_line_prefix.clone(),
+            })
+        }),
+    });
+    win.cursor = (count, 0).into();
+
+    Ok(())
+}
+
+pub fn open(
+    mut ctx: KeyHandlerContext<VimKeymap>,
+    history_key: String,
+    prompt_key: String,
+) -> KeyResult<()> {
+    let history = ctx.keymap.histories.take(&history_key);
+
+    open_from_history(&mut ctx, &history, history_key.clone(), prompt_key)?;
+
+    ctx.keymap
+        .histories
+        .replace(history_key.to_string(), history);
+
+    Ok(())
+}

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -1,3 +1,4 @@
+mod cmdline;
 mod insert;
 mod mode_stack;
 mod motion;

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -75,7 +75,9 @@ fn cmd_mode_access() -> KeyTreeNode {
             let mut conns = ctx.state_mut().connections.take().expect("Connections obj missing");
             let result = if let Some(conn) = conns.by_buffer_id(buffer_id) {
                 let history = &conn.game.history;
-                cmdline::open_from_history(&mut ctx, history, "!".to_string(), "!".into())
+
+                // FIXME: Handle sending the submitted line to the conn
+                cmdline::open_from_history(&mut ctx, history, "!".to_string(), "".into())
             } else {
                 Err(KeyError::IO(std::io::ErrorKind::NotConnected.into()))
             };

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -6,25 +6,19 @@ pub mod search;
 mod window;
 
 use std::rc::Rc;
-use tui::style::{Color, Style};
-use tui::text::{Span, Spans};
 
+use crate::input::maps::vim::cmdline;
 use crate::input::{
     commands::CommandHandlerContext,
     completion::commands::CommandsCompleter,
-    keys::KeysParsable,
     maps::{KeyHandlerContext, KeyResult},
-    KeyError, KeymapContext, RemapMode, Remappable,
+    KeyError, KeymapContext,
 };
-use crate::input::{Key, KeyCode};
 use crate::{
-    editing::buffer::BufHidden,
-    editing::gutter::Gutter,
     editing::motion::char::CharMotion,
     editing::motion::linewise::{ToLineEndMotion, ToLineStartMotion},
     editing::motion::{Motion, MotionFlags, MotionRange},
-    editing::source::BufferSource,
-    editing::text::{EditableLine, TextLine},
+    editing::text::TextLine,
 };
 use crate::{key_handler, vim_tree};
 
@@ -50,127 +44,6 @@ fn handle_command(mut context: &mut CommandHandlerContext) -> KeyResult {
     }
 }
 
-fn cmdline_to_prompt(
-    mut ctx: KeyHandlerContext<VimKeymap>,
-    prompt_key: String,
-) -> KeyResult<KeyHandlerContext<VimKeymap>> {
-    let cmd = if let Some(cmd_spans) = ctx
-        .state()
-        .current_buffer()
-        .checked_get(ctx.state().current_window().cursor.line)
-    {
-        cmd_spans.to_string()
-    } else {
-        "".to_string()
-    };
-
-    // Release the buffer
-    let buffer_id = ctx.state().current_buffer().id();
-    ctx.state_mut().delete_buffer(buffer_id);
-
-    // Is this *too* hacky? Just feed each char as a key:
-    // Perhaps we should match on prompt_key and invoke eg `handle_command`,
-    // `handle_forward_search`, etc. directly...
-    ctx = ctx.feed_keys_noremap(prompt_key.into_keys())?;
-
-    let cmd_as_keys: Vec<Key> = cmd.chars().map(|ch| Key::from(KeyCode::Char(ch))).collect();
-    ctx = ctx.feed_keys_noremap(cmd_as_keys)?;
-    Ok(ctx)
-}
-
-fn cancel_cmdline(ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
-    cmdline_to_prompt(ctx, prompt_key)?;
-    Ok(())
-}
-
-fn submit_cmdline(ctx: KeyHandlerContext<VimKeymap>, prompt_key: String) -> KeyResult {
-    let ctx = cmdline_to_prompt(ctx, prompt_key)?;
-    ctx.feed_keys_noremap("<cr>".into_keys())?;
-    Ok(())
-}
-
-fn open_cmdline_mode(
-    mut ctx: KeyHandlerContext<VimKeymap>,
-    history_key: String,
-    prompt_key: String,
-) -> KeyResult<()> {
-    ctx.state_mut().clear_echo();
-    let win_id = ctx.state_mut().current_tab_mut().split_bottom();
-    let history = ctx.keymap.histories.take(&history_key);
-
-    let buffer = ctx.state_mut().buffers.create_mut();
-    let buf_id = buffer.id();
-    buffer.set_source(BufferSource::Cmdline);
-    buffer.config_mut().bufhidden = BufHidden::Delete;
-
-    let mut count = 0;
-    for entry in history.iter().rev() {
-        buffer.append_line(entry.to_string());
-        count += 1;
-    }
-
-    ctx.state_mut().current_tab_mut().set_focus(win_id);
-    ctx.state_mut().set_current_window_buffer(buf_id);
-    ctx.keymap
-        .histories
-        .replace(history_key.to_string(), history);
-
-    // Bind <cr> to submit the input
-    let normal_prompt_key = prompt_key.clone();
-    let insert_prompt_key = prompt_key.clone();
-    ctx.keymap.buf_remap_keys_fn(
-        buf_id,
-        RemapMode::VimNormal,
-        "<cr>".into_keys(),
-        Box::new(move |ctx| submit_cmdline(ctx, normal_prompt_key.to_string())),
-    );
-    ctx.keymap.buf_remap_keys_fn(
-        buf_id,
-        RemapMode::VimInsert,
-        "<cr>".into_keys(),
-        Box::new(move |ctx| submit_cmdline(ctx, insert_prompt_key.to_string())),
-    );
-
-    // Bind <ctrl-c> to cancel the mode
-    let normal_prompt_key = prompt_key.clone();
-    ctx.keymap.buf_remap_keys_fn(
-        buf_id,
-        RemapMode::VimNormal,
-        "<ctrl-c>".into_keys(),
-        Box::new(move |ctx| cancel_cmdline(ctx, normal_prompt_key.to_string())),
-    );
-    ctx.keymap.buf_remap_keys_fn(
-        buf_id,
-        RemapMode::VimInsert,
-        "<ctrl-c>".into_keys(),
-        Box::new(move |ctx| cancel_cmdline(ctx, prompt_key.to_string())),
-    );
-
-    let win = ctx.state_mut().current_tab_mut().by_id_mut(win_id).unwrap();
-
-    // TODO Resize to cmdwinheight
-
-    let non_line_prefix = vec![Span::styled("~", Style::default().fg(Color::DarkGray))];
-
-    let gutter_prefix = vec![Span::styled(
-        history_key,
-        Style::default().fg(Color::DarkGray),
-    )];
-
-    win.gutter = Some(Gutter {
-        width: 1,
-        get_content: Box::new(move |line| {
-            Spans(match line {
-                Some(_) => gutter_prefix.clone(),
-                None => non_line_prefix.clone(),
-            })
-        }),
-    });
-    win.cursor = (count, 0).into();
-
-    Ok(())
-}
-
 fn cmd_mode_access() -> KeyTreeNode {
     vim_tree! {
         ":" => |ctx| {
@@ -187,14 +60,29 @@ fn cmd_mode_access() -> KeyTreeNode {
         },
 
         "q:" => |?mut ctx| {
-            open_cmdline_mode(ctx, ":".to_string(), ":".into())
+            cmdline::open(ctx, ":".to_string(), ":".into())
         },
 
         "q/" => |?mut ctx| {
-            open_cmdline_mode(ctx, "/".to_string(), "/".into())
+            cmdline::open(ctx, "/".to_string(), "/".into())
         },
         "q?" => |?mut ctx| {
-            open_cmdline_mode(ctx, "/".to_string(), "?".into())
+            cmdline::open(ctx, "/".to_string(), "?".into())
+        },
+
+        "qi" => |ctx| {
+            let buffer_id = ctx.state().current_buffer().id();
+            let mut conns = ctx.state_mut().connections.take().expect("Connections obj missing");
+            let result = if let Some(conn) = conns.by_buffer_id(buffer_id) {
+                let history = &conn.game.history;
+                cmdline::open_from_history(&mut ctx, history, "!".to_string(), "!".into())
+            } else {
+                Err(KeyError::IO(std::io::ErrorKind::NotConnected.into()))
+            };
+
+            ctx.state_mut().connections = Some(conns);
+
+            result
         },
     }
 }

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -7,10 +7,10 @@ mod window;
 
 use std::rc::Rc;
 
-use crate::input::maps::vim::cmdline;
 use crate::input::{
     commands::CommandHandlerContext,
     completion::commands::CommandsCompleter,
+    maps::vim::cmdline::{self, CmdlineSink},
     maps::{KeyHandlerContext, KeyResult},
     KeyError, KeymapContext,
 };
@@ -60,14 +60,14 @@ fn cmd_mode_access() -> KeyTreeNode {
         },
 
         "q:" => |?mut ctx| {
-            cmdline::open(ctx, ":".to_string(), ":".into())
+            cmdline::open(ctx, ":".to_string(), CmdlineSink::SubmitPrompt(":"))
         },
 
         "q/" => |?mut ctx| {
-            cmdline::open(ctx, "/".to_string(), "/".into())
+            cmdline::open(ctx, "/".to_string(), CmdlineSink::SubmitPrompt("/"))
         },
         "q?" => |?mut ctx| {
-            cmdline::open(ctx, "/".to_string(), "?".into())
+            cmdline::open(ctx, "/".to_string(), CmdlineSink::SubmitPrompt("?"))
         },
 
         "qi" => |ctx| {
@@ -76,8 +76,7 @@ fn cmd_mode_access() -> KeyTreeNode {
             let result = if let Some(conn) = conns.by_buffer_id(buffer_id) {
                 let history = &conn.game.history;
 
-                // FIXME: Handle sending the submitted line to the conn
-                cmdline::open_from_history(&mut ctx, history, "!".to_string(), "".into())
+                cmdline::open_from_history(&mut ctx, history, "!".to_string(), CmdlineSink::ConnectionBuffer(buffer_id))
             } else {
                 Err(KeyError::IO(std::io::ErrorKind::NotConnected.into()))
             };

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -79,6 +79,7 @@ fn cmd_mode_access() -> KeyTreeNode {
                 &BufferSource::ConnectionInputForBuffer(conn_buff_id) => conn_buff_id,
                 _ => buffer_id,
             };
+
             let mut conns = ctx.state_mut().connections.take().expect("Connections obj missing");
             let result = if let Some(conn) = conns.by_buffer_id(buffer_id) {
                 let history = &conn.game.history;


### PR DESCRIPTION
Adds support for a basic connection input history, accessible via cmdline mode, mapped to `qi`.

- Store sent-message history on the GameEngine
- Support opening a cmdline window with input history
- Add support for submitting connection input from cmdline
- Fix extraneous keypresses for qi
- Fix: sending from cmdline cleared the buffer
- Fix: sending from cmdline appends sent text to wrong buffer

Some remaining opportunities for improvement:

- [x] Return to the connection input buffer's window on submit/cancel
- [x] Fill the connection input buffer on cancel
- [ ] Persist input history, at least across disconnect/reconnect—right now it's lost with the connection. (This might be better managed as part of a more complete feature to persist input history across app sessions, like judo has)
- [ ] Faster/more interactive history searching (probably in a future PR)
