### PR TITLE
Increase UI event poll duration to reduce idle CPU

### DIFF
--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -86,8 +86,8 @@ impl<U: UI, UE: UiEvents> KeySource for AppKeySource<U, UE> {
 
                 dirty = self.process_async(&mut keymap)?;
 
-                // finally, check for input:
-                match self.events.poll_event(Duration::from_millis(10))? {
+                // Finally, check for input:
+                match self.events.poll_event(Duration::from_millis(100))? {
                     Some(_) => break,
                     None => {}
                 }
@@ -95,7 +95,7 @@ impl<U: UI, UE: UiEvents> KeySource for AppKeySource<U, UE> {
 
             match self.events.next_event()? {
                 UiEvent::Key(key) => {
-                    // if dirty, render one more time before returning the key
+                    // If dirty, render one more time before returning the key
                     if dirty {
                         self.app.render();
                     }


### PR DESCRIPTION
Brings idle CPU usage down from ~1% to ~0%. Does not see to have too
noticeable of a negative perf implication and actually seems to make
network rendering *more* consistent, oddly enough (though this may just
be placebo).

This may cause scripting to be too slow, however.... It would be better
if we could actually do some sort of select() somehow instead of this
loop...