### PR TITLE
Rewrite the main loop for simplicity and perf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ genawaiter = "0.99.1"
 telnet = "0.2.1"
 url = "2.2.2"
 vte = "0.10.1"
-tokio = { version = "1.2.0", features = ["rt-multi-thread"] }
+tokio = { version = "1.2.0", features = ["rt-multi-thread", "sync"] }
 bitflags = "1.3.2"
 delegate = "0.6.1"
 backtrace = "0.3.63"

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -1,0 +1,108 @@
+use std::{
+    io,
+    sync::mpsc::{self, Receiver, Sender},
+    time::Duration,
+};
+
+use crate::app;
+use crate::input::{maps::KeyResult, Key, KeyError, KeySource};
+
+pub struct DispatchRecord<R> {
+    from_main: Receiver<R>,
+}
+
+impl<R> DispatchRecord<R> {
+    pub fn join(&self) -> KeyResult<R> {
+        Ok(self.from_main.recv().unwrap())
+    }
+
+    /// Wait for this Job to finish, returning a KeyResult representing
+    /// the result of the Job. This fn acts like it's blocking input,
+    /// but still allows the UI to redraw and also accepts <ctrl-c> input
+    /// from the user, which triggers a cancellation of this Job, returning
+    /// [`KeyError:Interrupted`] to the caller.
+    pub fn join_interruptably<K: KeySource>(&self, keys: &mut K) -> KeyResult<R> {
+        loop {
+            match self.from_main.recv_timeout(Duration::from_millis(50)) {
+                Ok(result) => return Ok(result),
+                Err(_) => {} // Receive timeout
+            }
+
+            if keys.poll_key(Duration::from_millis(50))? {
+                match keys.next_key()? {
+                    Some(key) if key == Key::from("<c-c>") => {
+                        return Err(KeyError::Interrupted);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+struct PendingDispatch<R: Send, F: FnOnce(&mut app::State) -> R + Send> {
+    f: Option<F>,
+    to_caller: Sender<R>,
+}
+
+impl<R: Send, F: FnOnce(&mut app::State) -> R + Send> PendingDispatch<R, F> {
+    #[allow(unused)]
+    pub fn execute(&mut self, state: &mut app::State) {
+        if let Some(f) = self.f.take() {
+            self.to_caller.send(f(state)).unwrap();
+        }
+    }
+}
+
+type BoxedPendingDispatch = Box<dyn FnMut(&mut app::State)>;
+
+/// Provides access to the main thread
+pub struct Dispatcher {
+    to_main: Sender<BoxedPendingDispatch>,
+    rx: Receiver<BoxedPendingDispatch>,
+}
+
+impl Default for Dispatcher {
+    fn default() -> Self {
+        let (tx, rx) = mpsc::channel();
+        Dispatcher { to_main: tx, rx }
+    }
+}
+
+impl Dispatcher {
+    pub fn process(state: &mut app::State) -> io::Result<bool> {
+        if let Some(mut action) = state.dispatcher.next_action()? {
+            action(state);
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn next_action(&mut self) -> io::Result<Option<BoxedPendingDispatch>> {
+        // TODO Probably, do a hard recv or recv with a long timeout
+        match self.rx.try_recv() {
+            Ok(action) => Ok(Some(action)),
+            Err(mpsc::TryRecvError::Empty) => Ok(None),
+            Err(e) => Err(io::Error::new(io::ErrorKind::Other, e)),
+        }
+    }
+
+    pub fn spawn<R, F>(&mut self, f: F) -> DispatchRecord<R>
+    where
+        R: Send + 'static,
+        F: FnOnce(&mut app::State) -> R + Send + 'static,
+    {
+        let (tx, rx) = mpsc::channel();
+        let mut pending = PendingDispatch {
+            f: Some(f),
+            to_caller: tx,
+        };
+
+        let b: BoxedPendingDispatch = Box::new(move |state| pending.execute(state));
+
+        self.to_main.send(b).unwrap();
+
+        DispatchRecord { from_main: rx }
+    }
+}

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -67,8 +67,7 @@ impl<R: Send, F: FnOnce(&mut CommandHandlerContext) -> R + Send> PendingDispatch
 
 type BoxedPendingDispatch = Box<dyn FnMut(&mut CommandHandlerContext) + Send>;
 
-/// Provides access to the main thread. The sender side may be trivially
-/// cloned
+/// Provides access to the main thread. The sender side may be trivially cloned
 pub struct Dispatcher {
     pub sender: DispatchSender,
     rx: Receiver<BoxedPendingDispatch>,

--- a/src/app/dispatcher.rs
+++ b/src/app/dispatcher.rs
@@ -106,6 +106,16 @@ impl Dispatcher {
         Ok(any_tasks)
     }
 
+    pub fn process_one(ctx: &mut CommandHandlerContext) -> bool {
+        match ctx.state_mut().dispatcher.rx.recv() {
+            Ok(mut action) => {
+                action(ctx);
+                true
+            }
+            Err(_) => false,
+        }
+    }
+
     fn next_action(&mut self) -> io::Result<Option<BoxedPendingDispatch>> {
         // TODO Probably, do a hard recv or recv with a long timeout
         match self.rx.try_recv() {

--- a/src/app/jobs.rs
+++ b/src/app/jobs.rs
@@ -10,7 +10,7 @@ use crate::{
     input::{maps::KeyResult, Key, KeyError, KeySource},
 };
 
-use super::dispatcher::DispatchSender;
+use super::dispatcher::{DispatchRecord, DispatchSender};
 
 const MAX_TASKS_PER_TICK: u16 = 10;
 
@@ -56,6 +56,14 @@ impl JobContext {
     {
         self.dispatcher.spawn(on_state).background();
         Ok(())
+    }
+
+    pub fn spawn<R, F>(&self, f: F) -> DispatchRecord<R>
+    where
+        R: Send + 'static,
+        F: FnOnce(&mut app::State) -> R + Send + 'static,
+    {
+        self.dispatcher.spawn(f)
     }
 }
 

--- a/src/app/jobs.rs
+++ b/src/app/jobs.rs
@@ -45,6 +45,7 @@ pub enum MainThreadAction {
     Err(Id),
 }
 
+#[derive(Clone)]
 pub struct JobContext {
     dispatcher: DispatchSender,
 }

--- a/src/app/jobs.rs
+++ b/src/app/jobs.rs
@@ -51,12 +51,11 @@ pub struct JobContext {
 }
 
 impl JobContext {
-    pub fn run<F>(&self, on_state: F) -> JobResult
+    pub fn run<F>(&self, on_state: F)
     where
-        F: (FnOnce(&mut app::State) -> JobResult) + Send + Sync + 'static,
+        F: (FnOnce(&mut app::State)) + Send + Sync + 'static,
     {
-        self.dispatcher.spawn(on_state).background();
-        Ok(())
+        self.spawn(on_state).background();
     }
 
     pub fn spawn<R, F>(&self, f: F) -> DispatchRecord<R>

--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -21,7 +21,7 @@ use crate::{
     script::ScriptingManager,
 };
 
-use super::jobs::Jobs;
+use super::{dispatcher::Dispatcher, jobs::Jobs};
 
 struct AppKeySource<U: UI, UE: UiEvents> {
     app: App<U>,
@@ -34,6 +34,9 @@ impl<U: UI, UE: UiEvents> AppKeySource<U, UE> {
         keymap: &mut Option<Box<&mut dyn BoxableKeymap>>,
     ) -> Result<bool, KeyError> {
         let mut dirty = false;
+
+        // New main loop processor:
+        dirty |= Dispatcher::process(&mut self.app.state)?;
 
         // process incoming data from connections
         if let Some(mut connections) = self.app.state.connections.take() {

--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -32,20 +32,13 @@ impl<U: UI, UE: UiEvents> AppKeySource<U, UE> {
         &mut self,
         keymap: &mut Option<Box<&mut dyn BoxableKeymap>>,
     ) -> Result<bool, KeyError> {
-        let mut dirty = false;
-
-        // New main loop processor:
-        dirty |= Dispatcher::process(&mut self.app.state)?;
-
         if let Some(ref mut keymap) = keymap {
-            // ... and from scripts
             let mut context = CommandHandlerContext::new_blank(self, keymap);
-            dirty |= ScriptingManager::process(&mut context)?;
+            // New main loop processor:
+            Ok(Dispatcher::process(&mut context)?)
         } else {
             panic!("No keymap provided");
         }
-
-        Ok(dirty)
     }
 }
 

--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -32,13 +32,9 @@ impl<U: UI, UE: UiEvents> AppKeySource<U, UE> {
         &mut self,
         keymap: &mut Option<Box<&mut dyn BoxableKeymap>>,
     ) -> Result<bool, KeyError> {
-        if let Some(ref mut keymap) = keymap {
-            let mut context = CommandHandlerContext::new_blank(self, keymap);
-            // New main loop processor:
-            Ok(Dispatcher::process(&mut context)?)
-        } else {
-            panic!("No keymap provided");
-        }
+        let keymap = keymap.as_mut().expect("No keymap provided");
+        let mut context = CommandHandlerContext::new_blank(self, keymap);
+        Ok(Dispatcher::process(&mut context)?)
     }
 }
 

--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -38,12 +38,6 @@ impl<U: UI, UE: UiEvents> AppKeySource<U, UE> {
         // New main loop processor:
         dirty |= Dispatcher::process(&mut self.app.state)?;
 
-        // process incoming data from connections
-        if let Some(mut connections) = self.app.state.connections.take() {
-            dirty |= connections.process(&mut self.app.state);
-            self.app.state.connections = Some(connections);
-        }
-
         // process messages from jobs
         dirty |= Jobs::process(&mut self.app.state)?;
 

--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -5,7 +5,6 @@ use std::{sync::Mutex, time::Duration};
 use crate::{
     app::{self, App},
     cli::{self, CliInit},
-    editing::text::TextLines,
     input::{
         commands::{connection::connect, CommandHandlerContext},
         maps::KeyResult,
@@ -21,7 +20,7 @@ use crate::{
     script::ScriptingManager,
 };
 
-use super::{dispatcher::Dispatcher, jobs::Jobs};
+use super::dispatcher::Dispatcher;
 
 struct AppKeySource<U: UI, UE: UiEvents> {
     app: App<U>,
@@ -37,9 +36,6 @@ impl<U: UI, UE: UiEvents> AppKeySource<U, UE> {
 
         // New main loop processor:
         dirty |= Dispatcher::process(&mut self.app.state)?;
-
-        // process messages from jobs
-        dirty |= Jobs::process(&mut self.app.state)?;
 
         if let Some(ref mut keymap) = keymap {
             // ... and from scripts
@@ -195,8 +191,5 @@ where
     U: UI,
     UE: UiEvents,
 {
-    let error = format!("ERR: {:?}", e);
-    for line in error.split("\n") {
-        app_keys.state_mut().echom(TextLines::raw(line.to_string()));
-    }
+    app_keys.state_mut().echom_error(e);
 }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,5 @@
 pub mod bufwin;
+pub mod dispatcher;
 pub mod help;
 pub mod jobs;
 pub mod looper;

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -305,6 +305,7 @@ impl Default for AppState {
     fn default() -> Self {
         let buffers = Buffers::new();
         let tabpages = Tabpages::new(Size { w: 0, h: 0 });
+        let dispatcher = Dispatcher::default();
         let mut app = Self {
             running: true,
             showing_splash: true,
@@ -320,8 +321,8 @@ impl Default for AppState {
             connections: Some(Connections::default()),
             scripting: Arc::new(Mutex::new(ScriptingManager::default())),
             api: Some(ApiManagerRpc::default()),
-            dispatcher: Default::default(),
-            jobs: Jobs::new(),
+            jobs: Jobs::new(dispatcher.sender.clone()),
+            dispatcher,
         };
 
         // create the default tabpage

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -19,7 +19,7 @@ use crate::{
         completion::CompletableContext,
         KeyError,
     },
-    script::{ApiManagerRpc, ScriptingManager},
+    script::ScriptingManager,
 };
 
 use super::{
@@ -53,7 +53,6 @@ pub struct AppState {
     pub connections: Option<Connections>,
 
     pub scripting: Arc<Mutex<ScriptingManager>>,
-    pub api: Option<ApiManagerRpc>,
 
     pub jobs: Jobs,
     pub dispatcher: Dispatcher,
@@ -320,7 +319,6 @@ impl Default for AppState {
             keymap_widget: None,
             connections: Some(Connections::default()),
             scripting: Arc::new(Mutex::new(ScriptingManager::default())),
-            api: Some(ApiManagerRpc::default()),
             jobs: Jobs::new(dispatcher.sender.clone()),
             dispatcher,
         };

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -24,6 +24,7 @@ use crate::{
 
 use super::{
     bufwin::BufWin,
+    dispatcher::Dispatcher,
     jobs::{JobError, Jobs},
     popup::PopupMenu,
     prompt::Prompt,
@@ -55,6 +56,7 @@ pub struct AppState {
     pub api: Option<ApiManagerRpc>,
 
     pub jobs: Jobs,
+    pub dispatcher: Dispatcher,
 }
 
 impl AppState {
@@ -318,6 +320,7 @@ impl Default for AppState {
             connections: Some(Connections::default()),
             scripting: Arc::new(Mutex::new(ScriptingManager::default())),
             api: Some(ApiManagerRpc::default()),
+            dispatcher: Default::default(),
             jobs: Jobs::new(),
         };
 

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -13,7 +13,7 @@ use super::{
     game::GameConnection,
     reader::{StopSignal, TransportReader},
     transport::Transport,
-    Connection, ConnectionFactories,
+    ConnectionFactories,
 };
 
 pub struct ConnectionRecord {
@@ -229,7 +229,21 @@ impl Connections {
     }
 
     #[cfg(test)]
-    pub fn add_for_test(&mut self, _buffer_id: Id, _connection: Box<dyn Connection>) {
-        // TODO
+    pub fn add_for_test(&mut self, buffer_id: Id, transport: Box<dyn Transport + Send>) {
+        let (stop_read_signal, _) = StopSignal::new();
+        let (outgoing, _) = mpsc::unbounded_channel();
+        let (_, outgoing_results) = std::sync::mpsc::channel();
+        self.add_record(
+            0,
+            buffer_id,
+            0,
+            ConnectionRecord {
+                id: 0,
+                stop_read_signal,
+                outgoing,
+                outgoing_results,
+                connection: GameConnection::with_engine(transport, Default::default()),
+            },
+        );
     }
 }

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -13,7 +13,7 @@ use super::{
     game::GameConnection,
     reader::{StopSignal, TransportReader},
     transport::Transport,
-    ConnectionFactories,
+    TransportFactories,
 };
 
 pub struct ConnectionRecord {
@@ -55,7 +55,7 @@ pub struct Connections {
     // be associated with ONLY ONE Buffer above (IE: the buffer it
     // writes to)
     buffer_to_connection: HashMap<Id, Id>,
-    factories: ConnectionFactories,
+    factories: TransportFactories,
 
     buffer_engines: HashMap<Id, GameEngine>,
 }
@@ -124,7 +124,7 @@ impl Connections {
         let factory = self.factories.clone();
 
         jobs.start(move |ctx| async move {
-            let connection = Mutex::new(factory.create(id, uri)?);
+            let connection = Mutex::new(factory.create(uri)?);
             let transport_context = Mutex::new(ctx.clone());
 
             ctx.run(move |state| {

--- a/src/connection/game.rs
+++ b/src/connection/game.rs
@@ -1,41 +1,46 @@
-use std::{io, time::Duration};
+use std::{
+    io,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use crate::game::engine::GameEngine;
 
 use super::{transport::Transport, ReadValue};
 
+#[derive(Clone)]
 pub struct GameConnection {
-    conn: Box<dyn Transport + Send>,
-    pub game: GameEngine,
+    conn: Arc<Mutex<Box<dyn Transport + Send>>>,
+    pub game: Arc<Mutex<GameEngine>>,
 }
 
 impl GameConnection {
     pub fn with_engine(conn: Box<dyn Transport + Send>, game: GameEngine) -> Self {
-        Self { conn, game }
-    }
-}
-
-impl From<Box<dyn Transport + Send>> for GameConnection {
-    fn from(conn: Box<dyn Transport + Send>) -> Self {
         Self {
-            conn,
-            game: GameEngine::default(),
+            conn: Arc::new(Mutex::new(conn)),
+            game: Arc::new(Mutex::new(game)),
         }
     }
 }
 
 impl Transport for GameConnection {
     fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>> {
-        if let Some(value) = self.conn.read_timeout(duration)? {
-            Ok(self.game.process_received(value))
+        if let Some(value) = self.conn.lock().unwrap().read_timeout(duration)? {
+            let mut game = self.game.lock().unwrap();
+            Ok(game.process_received(value))
         } else {
             Ok(None)
         }
     }
 
     fn send(&mut self, text: &str) -> io::Result<()> {
-        if let Some(processed) = self.game.process_to_send(text.to_string())? {
-            self.conn.send(&processed)
+        if let Some(processed) = self
+            .game
+            .lock()
+            .unwrap()
+            .process_to_send(text.to_string())?
+        {
+            self.conn.lock().unwrap().send(&processed)
         } else {
             Ok(())
         }

--- a/src/connection/game.rs
+++ b/src/connection/game.rs
@@ -1,24 +1,23 @@
 use delegate::delegate;
-use std::io;
+use std::{io, time::Duration};
 
-use crate::editing::Id;
 use crate::game::engine::GameEngine;
 
-use super::{Connection, ReadValue};
+use super::{transport::Transport, ReadValue};
 
 pub struct GameConnection {
-    conn: Box<dyn Connection>,
+    conn: Box<dyn Transport + Send>,
     pub game: GameEngine,
 }
 
 impl GameConnection {
-    pub fn with_engine(conn: Box<dyn Connection>, game: GameEngine) -> Self {
+    pub fn with_engine(conn: Box<dyn Transport + Send>, game: GameEngine) -> Self {
         Self { conn, game }
     }
 }
 
-impl From<Box<dyn Connection>> for GameConnection {
-    fn from(conn: Box<dyn Connection>) -> Self {
+impl From<Box<dyn Transport + Send>> for GameConnection {
+    fn from(conn: Box<dyn Transport + Send>) -> Self {
         Self {
             conn,
             game: GameEngine::default(),
@@ -26,19 +25,16 @@ impl From<Box<dyn Connection>> for GameConnection {
     }
 }
 
-impl Connection for GameConnection {
+impl Transport for GameConnection {
     delegate! {
         to (self.conn) {
-            fn id(&self) -> Id;
-            fn read(&mut self) -> io::Result<Option<ReadValue>>;
-            fn write(&mut self, bytes: &[u8]) -> io::Result<()>;
+            fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>>;
         }
     }
 
-    fn send(&mut self, text: String) -> io::Result<()> {
-        if let Some(processed) = self.game.process_to_send(text)? {
-            self.write(processed.as_bytes())?;
-            self.write(&vec!['\n' as u8])
+    fn send(&mut self, text: &str) -> io::Result<()> {
+        if let Some(processed) = self.game.process_to_send(text.to_string())? {
+            self.conn.send(&processed)
         } else {
             Ok(())
         }

--- a/src/connection/game.rs
+++ b/src/connection/game.rs
@@ -1,4 +1,3 @@
-use delegate::delegate;
 use std::{io, time::Duration};
 
 use crate::game::engine::GameEngine;
@@ -26,9 +25,11 @@ impl From<Box<dyn Transport + Send>> for GameConnection {
 }
 
 impl Transport for GameConnection {
-    delegate! {
-        to (self.conn) {
-            fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>>;
+    fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>> {
+        if let Some(value) = self.conn.read_timeout(duration)? {
+            Ok(self.game.process_received(value))
+        } else {
+            Ok(None)
         }
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -12,7 +12,7 @@ pub mod game;
 mod reader;
 mod telnet;
 mod tls;
-mod transport;
+pub mod transport;
 
 #[derive(Debug, PartialEq)]
 pub enum ReadValue {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -9,6 +9,7 @@ use self::{telnet::TelnetConnectionFactory, transport::Transport};
 mod ansi;
 pub mod connections;
 pub mod game;
+mod reader;
 mod telnet;
 mod tls;
 mod transport;

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use url::Url;
 
-use crate::editing::{text::TextLine, Id};
+use crate::editing::text::TextLine;
 
 use self::{telnet::TelnetConnectionFactory, transport::Transport};
 
@@ -20,43 +20,33 @@ pub enum ReadValue {
     Text(TextLine),
 }
 
-pub trait Connection {
-    fn id(&self) -> Id;
-    fn read(&mut self) -> io::Result<Option<ReadValue>>;
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()>;
-    fn send(&mut self, text: String) -> io::Result<()> {
-        self.write(text.as_bytes())?;
-        self.write(&vec!['\n' as u8])
-    }
+pub trait TransportFactory: Send + Sync {
+    fn clone_boxed(&self) -> Box<dyn TransportFactory>;
+    fn create(&self, uri: &Url) -> Option<io::Result<Box<dyn Transport + Send>>>;
 }
 
-pub trait ConnectionFactory: Send + Sync {
-    fn clone_boxed(&self) -> Box<dyn ConnectionFactory>;
-    fn create(&self, id: Id, uri: &Url) -> Option<io::Result<Box<dyn Transport + Send>>>;
+pub struct TransportFactories {
+    factories: Vec<Box<dyn TransportFactory>>,
 }
 
-pub struct ConnectionFactories {
-    factories: Vec<Box<dyn ConnectionFactory>>,
-}
-
-impl Default for ConnectionFactories {
+impl Default for TransportFactories {
     fn default() -> Self {
-        ConnectionFactories {
+        TransportFactories {
             factories: vec![Box::new(TelnetConnectionFactory)],
         }
     }
 }
 
-impl ConnectionFactories {
+impl TransportFactories {
     pub fn clone(&self) -> Self {
         Self {
             factories: self.factories.iter().map(|f| f.clone_boxed()).collect(),
         }
     }
 
-    pub fn create(&self, id: Id, uri: Url) -> io::Result<Box<dyn Transport + Send>> {
+    pub fn create(&self, uri: Url) -> io::Result<Box<dyn Transport + Send>> {
         for f in &self.factories {
-            match f.create(id, &uri) {
+            match f.create(&uri) {
                 None => {} // unsupported
                 Some(Ok(conn)) => return Ok(conn),
                 Some(Err(e)) => return Err(e),

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -11,6 +11,7 @@ pub mod connections;
 pub mod game;
 mod telnet;
 mod tls;
+mod transport;
 
 #[derive(Debug, PartialEq)]
 pub enum ReadValue {

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -4,7 +4,7 @@ use url::Url;
 
 use crate::editing::{text::TextLine, Id};
 
-use self::telnet::TelnetConnectionFactory;
+use self::{telnet::TelnetConnectionFactory, transport::Transport};
 
 mod ansi;
 pub mod connections;
@@ -31,7 +31,7 @@ pub trait Connection {
 
 pub trait ConnectionFactory: Send + Sync {
     fn clone_boxed(&self) -> Box<dyn ConnectionFactory>;
-    fn create(&self, id: Id, uri: &Url) -> Option<io::Result<Box<dyn Connection + Send>>>;
+    fn create(&self, id: Id, uri: &Url) -> Option<io::Result<Box<dyn Transport + Send>>>;
 }
 
 pub struct ConnectionFactories {
@@ -53,7 +53,7 @@ impl ConnectionFactories {
         }
     }
 
-    pub fn create(&self, id: Id, uri: Url) -> io::Result<Box<dyn Connection + Send>> {
+    pub fn create(&self, id: Id, uri: Url) -> io::Result<Box<dyn Transport + Send>> {
         for f in &self.factories {
             match f.create(id, &uri) {
                 None => {} // unsupported

--- a/src/connection/reader.rs
+++ b/src/connection/reader.rs
@@ -1,0 +1,97 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use tokio::sync::oneshot::{self, error::TryRecvError, Sender};
+
+use crate::{app::jobs::JobContext, editing::Id};
+
+use super::transport::Transport;
+
+pub struct StopSignal {
+    tx: Option<Sender<()>>,
+}
+
+impl StopSignal {
+    pub fn stop(&mut self) {
+        if let Some(tx) = self.tx.take() {
+            // If it failed, then we probably already stopped reading
+            tx.send(()).ok();
+        }
+    }
+}
+
+impl Drop for StopSignal {
+    fn drop(&mut self) {
+        self.stop();
+    }
+}
+
+pub struct TransportReader {
+    ctx: JobContext,
+    buffer_id: Id,
+    transport: Arc<Mutex<Box<dyn Transport + Send>>>,
+}
+
+impl TransportReader {
+    pub fn spawn(
+        ctx: JobContext,
+        buffer_id: Id,
+        transport: Arc<Mutex<Box<dyn Transport + Send>>>,
+    ) -> StopSignal {
+        let (tx, rx) = oneshot::channel();
+
+        tokio::task::spawn_blocking(move || {
+            let mut reader = TransportReader {
+                ctx,
+                buffer_id,
+                transport,
+            };
+            reader.loop_until(rx);
+        });
+
+        StopSignal { tx: Some(tx) }
+    }
+
+    pub fn loop_until(&mut self, mut signal: oneshot::Receiver<()>) {
+        loop {
+            match signal.try_recv() {
+                Err(TryRecvError::Empty) => {} // Nop
+                _ => break,                    // Any other message, we should drop the connection
+            }
+
+            if !self.read_once() {
+                break;
+            }
+        }
+    }
+
+    fn read_once(&mut self) -> bool {
+        let mut conn = self.transport.lock().unwrap();
+        let read = conn.read_timeout(Duration::from_millis(250));
+        if let Ok(None) = read {
+            // Nothing read
+            return true;
+        }
+
+        let buffer_id = self.buffer_id;
+        self.ctx
+            .spawn(move |state| {
+                let mut buffer = state
+                    .winsbuf_by_id(buffer_id)
+                    .expect("Could not find buffer for connection");
+                match read {
+                    Ok(Some(value)) => buffer.append_value(value),
+                    Ok(None) => {} // nop
+                    Err(e) => {
+                        buffer.append(format!("Disconnected: {}", e).into());
+                        return false;
+                    }
+                }
+                true
+            })
+            .join()
+            .expect("Spawn error")
+    }
+}

--- a/src/connection/reader.rs
+++ b/src/connection/reader.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{thread::yield_now, time::Duration};
 
 use tokio::sync::oneshot::{self, error::TryRecvError, Sender};
 
@@ -64,6 +64,8 @@ impl<T: Transport + Send + 'static> TransportReader<T> {
             if !self.read_once() {
                 break;
             }
+
+            yield_now();
         }
     }
 

--- a/src/connection/reader.rs
+++ b/src/connection/reader.rs
@@ -28,18 +28,14 @@ impl Drop for StopSignal {
     }
 }
 
-pub struct TransportReader {
+pub struct TransportReader<T: Transport> {
     ctx: JobContext,
     buffer_id: Id,
-    transport: Arc<Mutex<Box<dyn Transport + Send>>>,
+    transport: Arc<Mutex<T>>,
 }
 
-impl TransportReader {
-    pub fn spawn(
-        ctx: JobContext,
-        buffer_id: Id,
-        transport: Arc<Mutex<Box<dyn Transport + Send>>>,
-    ) -> StopSignal {
+impl<T: Transport + Send + 'static> TransportReader<T> {
+    pub fn spawn(ctx: JobContext, buffer_id: Id, transport: Arc<Mutex<T>>) -> StopSignal {
         let (tx, rx) = oneshot::channel();
 
         tokio::task::spawn_blocking(move || {

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -92,7 +92,7 @@ impl ConnectionFactory for TelnetConnectionFactory {
         Box::new(TelnetConnectionFactory)
     }
 
-    fn create(&self, id: Id, uri: &Url) -> Option<std::io::Result<Box<dyn Connection + Send>>> {
+    fn create(&self, id: Id, uri: &Url) -> Option<std::io::Result<Box<dyn Transport + Send>>> {
         let secure = match uri.scheme() {
             "telnet" => false,
             "ssl" => true,

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -5,16 +5,11 @@ use std::net::TcpStream;
 use telnet::Telnet;
 use url::Url;
 
-use crate::editing::Id;
-
-use super::{
-    ansi::AnsiPipeline, tls, transport::Transport, Connection, ConnectionFactory, ReadValue,
-};
+use super::{ansi::AnsiPipeline, tls, transport::Transport, ReadValue, TransportFactory};
 
 const BUFFER_SIZE: usize = 2048;
 
 pub struct TelnetConnection {
-    id: Id,
     telnet: Telnet,
     pipeline: AnsiPipeline,
 }
@@ -46,22 +41,6 @@ impl TelnetConnection {
     }
 }
 
-impl Connection for TelnetConnection {
-    fn id(&self) -> Id {
-        self.id
-    }
-
-    fn read(&mut self) -> io::Result<Option<ReadValue>> {
-        let event = self.telnet.read_nonblocking()?;
-        self.process_event(event)
-    }
-
-    fn write(&mut self, bytes: &[u8]) -> io::Result<()> {
-        self.telnet.write(bytes)?;
-        Ok(())
-    }
-}
-
 impl Transport for TelnetConnection {
     fn read_timeout(&mut self, duration: std::time::Duration) -> io::Result<Option<ReadValue>> {
         if let Some(pending) = self.pipeline.next() {
@@ -73,8 +52,9 @@ impl Transport for TelnetConnection {
     }
 
     fn send(&mut self, text: &str) -> io::Result<()> {
-        self.write(text.as_bytes())?;
-        self.write(b"\r\n")
+        self.telnet.write(text.as_bytes())?;
+        self.telnet.write(b"\r\n")?;
+        Ok(())
     }
 }
 
@@ -92,12 +72,12 @@ fn connect(host: &str, port: u16, secure: bool, buffer_size: usize) -> io::Resul
 }
 
 pub struct TelnetConnectionFactory;
-impl ConnectionFactory for TelnetConnectionFactory {
-    fn clone_boxed(&self) -> Box<dyn ConnectionFactory> {
+impl TransportFactory for TelnetConnectionFactory {
+    fn clone_boxed(&self) -> Box<dyn TransportFactory> {
         Box::new(TelnetConnectionFactory)
     }
 
-    fn create(&self, id: Id, uri: &Url) -> Option<std::io::Result<Box<dyn Transport + Send>>> {
+    fn create(&self, uri: &Url) -> Option<std::io::Result<Box<dyn Transport + Send>>> {
         let secure = match uri.scheme() {
             "telnet" => false,
             "ssl" => true,
@@ -107,7 +87,6 @@ impl ConnectionFactory for TelnetConnectionFactory {
         match (uri.host_str(), uri.port()) {
             (Some(host), Some(port)) => match connect(host, port, secure, BUFFER_SIZE) {
                 Ok(conn) => Some(Ok(Box::new(TelnetConnection {
-                    id,
                     telnet: conn,
                     pipeline: AnsiPipeline::new(),
                 }))),

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -73,7 +73,8 @@ impl Transport for TelnetConnection {
     }
 
     fn send(&mut self, text: &str) -> io::Result<()> {
-        self.write(text.as_bytes())
+        self.write(text.as_bytes())?;
+        self.write(b"\r\n")
     }
 }
 

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -64,6 +64,10 @@ impl Connection for TelnetConnection {
 
 impl Transport for TelnetConnection {
     fn read_timeout(&mut self, duration: std::time::Duration) -> io::Result<Option<ReadValue>> {
+        if let Some(pending) = self.pipeline.next() {
+            return Ok(Some(pending));
+        }
+
         let event = self.telnet.read_timeout(duration)?;
         self.process_event(event)
     }

--- a/src/connection/transport.rs
+++ b/src/connection/transport.rs
@@ -1,0 +1,8 @@
+use std::{io, time::Duration};
+
+use super::ReadValue;
+
+pub trait Transport {
+    fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>>;
+    fn send(&mut self, text: &str) -> io::Result<()>;
+}

--- a/src/game/completion/factory.rs
+++ b/src/game/completion/factory.rs
@@ -7,7 +7,7 @@ use crate::game::completion::{CompletionSource, ProcessFlags};
 
 pub struct GameCompletionsFactory;
 
-fn create_sent_source() -> MultiplexCompletionSource<Box<dyn SimpleCompletionSource>> {
+fn create_sent_source() -> MultiplexCompletionSource<Box<dyn SimpleCompletionSource + Send>> {
     MultiplexCompletionSource {
         sources: vec![
             Box::new(MarkovCompletionSource::default()),
@@ -30,7 +30,7 @@ fn create_sent_source() -> MultiplexCompletionSource<Box<dyn SimpleCompletionSou
 }
 
 impl GameCompletionsFactory {
-    pub fn create() -> MultiplexCompletionSource<Box<dyn CompletionSource>> {
+    pub fn create() -> MultiplexCompletionSource<Box<dyn CompletionSource + Send>> {
         let sent_source =
             FlaggedCompletionSource::accepting_flags(create_sent_source(), ProcessFlags::SENT);
 

--- a/src/game/completion/multiplex.rs
+++ b/src/game/completion/multiplex.rs
@@ -19,17 +19,17 @@ pub trait MultiplexSelector {
 }
 
 pub trait MultiplexSelectorFactory {
-    fn create(&self, context: CompletionContext) -> Box<dyn MultiplexSelector>;
+    fn create(&self, context: CompletionContext) -> Box<dyn MultiplexSelector + Send>;
 }
 
 pub struct MultiplexCompletionSource<T: Completer> {
     pub sources: Vec<T>,
-    pub selector_factory: Box<dyn MultiplexSelectorFactory>,
+    pub selector_factory: Box<dyn MultiplexSelectorFactory + Send>,
 }
 
 fn produce_next(
     sources: &mut Vec<Peekable<BoxedSuggestions>>,
-    selector: &mut Box<dyn MultiplexSelector>,
+    selector: &mut Box<dyn MultiplexSelector + Send>,
 ) -> Option<Completion> {
     let candidates: Vec<Option<&Completion>> =
         sources.iter_mut().map(|source| source.peek()).collect();
@@ -116,7 +116,7 @@ mod tests {
         fn create(
             &self,
             _: crate::input::completion::CompletionContext,
-        ) -> Box<(dyn MultiplexSelector + 'static)> {
+        ) -> Box<(dyn MultiplexSelector + Send + 'static)> {
             Box::new(self.clone())
         }
     }

--- a/src/game/completion/multiplex/word_index.rs
+++ b/src/game/completion/multiplex/word_index.rs
@@ -13,7 +13,7 @@ impl WordIndexWeightedRandomSelector {
 }
 
 impl MultiplexSelectorFactory for WordIndexWeightedRandomSelector {
-    fn create(&self, context: CompletionContext) -> Box<dyn super::MultiplexSelector> {
+    fn create(&self, context: CompletionContext) -> Box<dyn super::MultiplexSelector + Send> {
         let index = context.word_index().max(self.weights_by_index.len() - 1);
         let weights = &self.weights_by_index[index];
         WeightedRandomSelectorFactory::with_weights(weights.clone()).create(context)

--- a/src/game/processing/alias.rs
+++ b/src/game/processing/alias.rs
@@ -12,7 +12,7 @@ use super::{
     ProcessedText, ProcessedTextFlags, TextInput, TextProcessor,
 };
 
-type Processor = dyn Fn(Match) -> KeyResult<Option<TextLine>>;
+type Processor = dyn Fn(Match) -> KeyResult<Option<TextLine>> + Send;
 
 pub struct Alias {
     matcher: Matcher,
@@ -99,7 +99,7 @@ impl TextProcessorManager<Alias> {
     pub fn insert_fn(
         &mut self,
         pattern: String,
-        replacement: Box<dyn Fn(HashMap<String, String>) -> KeyResult<Option<String>>>,
+        replacement: Box<dyn Fn(HashMap<String, String>) -> KeyResult<Option<String>> + Send>,
     ) -> KeyResult {
         let alias = Alias::compile_fn(
             pattern.to_string(),

--- a/src/input/commands/helpers.rs
+++ b/src/input/commands/helpers.rs
@@ -95,23 +95,25 @@ mod tests {
 
     #[cfg(test)]
     mod check_hide_buffer {
+        use std::time::Duration;
+
+        use crate::connection::transport::Transport;
+        use crate::editing::motion::tests::TestKeyHandlerContext;
         use crate::editing::FocusDirection;
-        use crate::{connection::Connection, editing::motion::tests::TestKeyHandlerContext};
 
         use super::*;
 
-        struct TestConnection;
+        struct TestTransport;
 
-        impl Connection for TestConnection {
-            fn id(&self) -> Id {
-                0
-            }
-
-            fn read(&mut self) -> std::io::Result<Option<crate::connection::ReadValue>> {
+        impl Transport for TestTransport {
+            fn read_timeout(
+                &mut self,
+                _timeout: Duration,
+            ) -> std::io::Result<Option<crate::connection::ReadValue>> {
                 Ok(None)
             }
 
-            fn write(&mut self, _bytes: &[u8]) -> std::io::Result<()> {
+            fn send(&mut self, _text: &str) -> std::io::Result<()> {
                 Ok(())
             }
         }
@@ -133,7 +135,7 @@ mod tests {
                 .connections
                 .as_mut()
                 .unwrap()
-                .add_for_test(buf_id, Box::new(TestConnection));
+                .add_for_test(buf_id, Box::new(TestTransport));
 
             // we should not be able to hide a single, connected window
             let connected = check_hide_buffer(&mut ctx, HideBufArgs { force: false });

--- a/src/input/commands/script.rs
+++ b/src/input/commands/script.rs
@@ -51,7 +51,7 @@ fn source_path(context: &mut CommandHandlerContext, file_path: PathBuf) -> KeyRe
         .and_then(|conns| conns.by_buffer_id(buffer_id))
     {
         // Clear config on any associated connection
-        conn.game.reset();
+        conn.with_engine_mut(|engine| engine.reset());
     }
 
     let path_str = file_path.to_string_lossy().to_string();

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -1,7 +1,7 @@
 use std::io;
 
 use crate::{
-    connection::{Connection, ReadValue},
+    connection::ReadValue,
     editing::{source::BufferSource, window::WindowFlags},
 };
 use crate::{

--- a/src/input/maps/vim/cmdline.rs
+++ b/src/input/maps/vim/cmdline.rs
@@ -4,7 +4,6 @@ use tui::{
 };
 
 use crate::{
-    connection::Connection,
     editing::{buffer::BufHidden, gutter::Gutter, source::BufferSource},
     input::{
         keys::KeysParsable,
@@ -62,7 +61,7 @@ fn cmdline_to_prompt(
                 .connections
                 .as_mut()
                 .and_then(|conns| conns.by_buffer_id(conn_buffer_id))
-                .map(|conn| conn.id())
+                .map(|conn| conn.id)
                 .and_then(|conn_id| ctx.state().conn_input_buffer_id(conn_id))
             {
                 let found_window = ctx

--- a/src/input/maps/vim/normal.rs
+++ b/src/input/maps/vim/normal.rs
@@ -82,9 +82,12 @@ fn cmd_mode_access() -> KeyTreeNode {
 
             let mut conns = ctx.state_mut().connections.take().expect("Connections obj missing");
             let result = if let Some(conn) = conns.by_buffer_id(buffer_id) {
-                let history = &conn.game.history;
+                conn.with_engine(|engine| {
+                    let history = &engine.history;
 
-                cmdline::open_from_history(&mut ctx, history, "!".to_string(), CmdlineSink::ConnectionBuffer(conn_buffer_id))
+                    cmdline::open_from_history(&mut ctx, history, "!".to_string(), CmdlineSink::ConnectionBuffer(conn_buffer_id))
+                })
+
             } else {
                 Err(KeyError::IO(std::io::ErrorKind::NotConnected.into()))
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,9 +32,10 @@ fn main_loop() -> io::Result<()> {
         demo::perform_demo(&mut app);
     }
 
+    let dispatcher = app.state.dispatcher.sender.clone();
     app_loop(
         app,
-        tui::events::TuiEvents::default(),
+        tui::events::TuiEvents::start_with_dispatcher(dispatcher),
         VimKeymap::default(),
         args,
     );

--- a/src/script/api/buffer.rs
+++ b/src/script/api/buffer.rs
@@ -82,7 +82,7 @@ impl BufferApiObject {
 fn create_user_processor(
     scripting: Arc<Mutex<ScriptingManager>>,
     f: ScriptingFnRef,
-) -> Box<dyn Fn(HashMap<String, String>) -> KeyResult<Option<String>>> {
+) -> Box<dyn Fn(HashMap<String, String>) -> KeyResult<Option<String>> + Send> {
     Box::new(move |groups| match scripting.try_lock() {
         Ok(scripting) => match scripting.invoke(f, groups.into())? {
             FnArgs::None => Ok(None),

--- a/src/script/python/mod.rs
+++ b/src/script/python/mod.rs
@@ -19,7 +19,7 @@ use crate::{
 use self::{modules::ModuleContained, util::unwrap_error};
 
 use super::{
-    api::{core::IaidoCore, ApiManagerDelegate},
+    api::{core::IaidoCore, Api},
     args::FnArgs,
     bindings::ScriptFile,
     fns::{FnManager, NativeFn, ScriptingFnRef},
@@ -46,7 +46,7 @@ fn declare_module(vm: &vm::VirtualMachine, name: &str, module: vm::pyobject::PyO
 }
 
 impl PythonScriptingRuntime {
-    fn new(id: Id, api: ApiManagerDelegate) -> Self {
+    fn new(id: Id, api: Api) -> Self {
         let mut runtime = PythonScriptingRuntime {
             fns: Arc::new(Mutex::new(FnManager::new(id))),
             vm: Default::default(),
@@ -140,7 +140,7 @@ impl ScriptingRuntime for PythonScriptingRuntime {
 
 pub struct PythonScriptingRuntimeFactory;
 impl ScriptingRuntimeFactory for PythonScriptingRuntimeFactory {
-    fn create(&self, id: Id, app: ApiManagerDelegate) -> Box<dyn ScriptingRuntime + Send> {
+    fn create(&self, id: Id, app: Api) -> Box<dyn ScriptingRuntime + Send> {
         Box::new(PythonScriptingRuntime::new(id, app))
     }
 

--- a/src/tui/events.rs
+++ b/src/tui/events.rs
@@ -1,8 +1,17 @@
-use std::{io, time::Duration};
+use std::{
+    collections::VecDeque,
+    io,
+    sync::{
+        mpsc::{self, Receiver},
+        Arc, Mutex,
+    },
+    time::Duration,
+};
 
 use crossterm::event::{Event, KeyCode, KeyModifiers};
 
 use crate::{
+    app::dispatcher::DispatchSender,
     input::Key,
     ui::{UiEvent, UiEvents},
 };
@@ -46,46 +55,71 @@ impl From<crossterm::event::KeyEvent> for Key {
 // ======= TuiEvents ======================================
 
 pub struct TuiEvents {
-    pending_event: Option<UiEvent>,
+    running: Arc<Mutex<bool>>,
+    events: Receiver<UiEvent>,
+    pending_events: VecDeque<UiEvent>,
 }
 
-impl Default for TuiEvents {
-    fn default() -> Self {
+impl TuiEvents {
+    pub fn start_with_dispatcher(dispatcher: DispatchSender) -> Self {
+        let running = Arc::new(Mutex::new(true));
+        let (tx, events) = mpsc::channel();
+
+        let running_ref = running.clone();
+        tokio::runtime::Handle::current().spawn_blocking(move || {
+            while *running_ref.lock().unwrap() {
+                let event = match crossterm::event::read() {
+                    Ok(Event::Resize(_, _)) => UiEvent::Redraw,
+                    Ok(Event::Key(key)) => UiEvent::Key(key.into()),
+                    Ok(Event::Mouse(_)) => UiEvent::Redraw,
+                    // TODO dispatch error?
+                    _ => break,
+                };
+
+                tx.send(event).ok();
+
+                // Dispatch a nop to the main thread to ensure we stop
+                // waiting and check for events
+                dispatcher.spawn(|_| ()).background();
+            }
+        });
+
         Self {
-            pending_event: None,
+            running,
+            events,
+            pending_events: Default::default(),
+        }
+    }
+}
+
+impl Drop for TuiEvents {
+    fn drop(&mut self) {
+        if let Ok(mut lock) = self.running.lock() {
+            *lock = false;
         }
     }
 }
 
 impl UiEvents for TuiEvents {
     fn poll_event(&mut self, timeout: Duration) -> io::Result<Option<UiEvent>> {
-        match crossterm::event::poll(timeout) {
-            Ok(found) if found => {
-                if let Some(pending) = self.pending_event {
-                    // unconsumed pending event; return unchanged:
-                    Ok(Some(pending))
-                } else {
-                    let next = self.next_event()?;
-                    self.pending_event = Some(next);
-                    Ok(Some(next))
-                }
+        if let Some(pending) = self.pending_events.front() {
+            return Ok(Some(pending.clone()));
+        }
+
+        match self.events.recv_timeout(timeout) {
+            Ok(received) => {
+                self.pending_events.push_front(received);
+                Ok(Some(received))
             }
-            Ok(_) => Ok(None),
-            Err(e) => Err(e),
+            _ => Ok(None),
         }
     }
 
-    fn next_event(&mut self) -> Result<UiEvent, io::Error> {
-        if let Some(pending) = self.pending_event {
-            self.pending_event = None;
+    fn next_event(&mut self) -> io::Result<UiEvent> {
+        if let Some(pending) = self.pending_events.pop_front() {
             return Ok(pending);
         }
 
-        match crossterm::event::read() {
-            Ok(Event::Resize(_, _)) => Ok(UiEvent::Redraw),
-            Ok(Event::Key(key)) => Ok(UiEvent::Key(key.into())),
-            Ok(Event::Mouse(_)) => Ok(UiEvent::Redraw),
-            Err(e) => Err(e),
-        }
+        Ok(self.events.recv().unwrap())
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,7 +8,6 @@ use crate::{editing::text::TextLine, input::Key};
 pub enum UiEvent {
     Redraw,
     Key(Key),
-    // UiThreadFn(Box<dyn Fn() + Send>), // ?
 }
 
 pub trait UI {


### PR DESCRIPTION
This is a massive refactor that consolidates all the many ways we have of getting onto the main thread into a single Dispatcher abstraction. In particular:

- The main loop is no longer a loop around many tiny sleeps, and instead is exclusively a "wait" on a channel, which should overall reduce power usage since the vast majority of time in a MUD is probably waiting for something to happen (either output from the server, or input from the user).
- Connections are rewritten to be multi-threaded
- The "Connection" abstraction was renamed to "Transport," which better describes how it is used
- Jobs still exist as a means of supporting multi-threaded work, but they access the main thread through Dispatcher (including support for results!)
- Scripts (of course) also access the main thread via Dispatcher
- Main thread dispatches are handled in batches; if multiple come in at once, we consistently handle them all so long as we don't have to do a blocking read to get them, and the elapsed processing time does not exceed one "frame" of time.
- Complete removed the `ApiManagerDelegate` since we no longer need it; this solves the discussion around re-entrant scripting since we don't have to remove anything from `app::State` to respond to scripting methods.

May just be placebo, but things do feel a bit snappier now!

Future work might:
- Rewrite Telnet support using on Tokio's async TCP connections
- Refactor Dispatcher to receive an Enum so we can provide an explicit "There's a pending key" signal that shortcuts out of whatever it's doing
- Refactor Connections to not be `Option` on `app::State`; not strictly necessary (or very relevant to this PR) but also I don't think we need it, and that refactor would certainly simplify access to connections