### PR TITLE
Refactor Connections property to be non-Optional

### DIFF
--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -51,7 +51,7 @@ pub struct AppState {
 
     // Connections should generally be available, but is an
     // Option so callers may temporarily take ownership of it
-    pub connections: Option<Connections>,
+    pub connections: Connections,
 
     pub scripting: Arc<Mutex<ScriptingManager>>,
 
@@ -285,16 +285,13 @@ impl AppState {
     }
 
     pub fn conn_input_buffer_id(&self, conn_id: Id) -> Option<Id> {
-        if let Some((Some(output_buffer_id), buffer_ids)) = self
-            .connections
-            .as_ref()
-            .map(|conns| (conns.id_to_buffer(conn_id), conns.id_to_buffers(conn_id)))
-        {
+        if let Some(output_buffer_id) = self.connections.id_to_buffer(conn_id) {
             // NOTE: There should be two buffer IDs per connection: the input
             // and the output. We have a direct mapping to the output buffer,
             // but don't frequently need to find the input buffer (yet) so
             // this is a somewhat straightforward way to look it up
-            buffer_ids
+            self.connections
+                .id_to_buffers(conn_id)
                 .into_iter()
                 .filter(|id| id != &output_buffer_id)
                 .next()
@@ -322,7 +319,7 @@ impl Default for AppState {
             prompt: Prompt::default(),
             builtin_commands: create_builtin_commands(),
             keymap_widget: None,
-            connections: Some(Connections::default()),
+            connections: Connections::default(),
             scripting: Arc::new(Mutex::new(ScriptingManager::default())),
             jobs: Jobs::new(dispatcher.sender.clone()),
             dispatcher,

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -128,7 +128,7 @@ impl Connections {
             let transport_context = Mutex::new(ctx.clone());
 
             ctx.run(move |state| {
-                state.connections.as_mut().unwrap().add_transport(
+                state.connections.add_transport(
                     transport_context.into_inner().unwrap(),
                     id,
                     buffer_id,

--- a/src/connection/reader.rs
+++ b/src/connection/reader.rs
@@ -50,7 +50,7 @@ impl<T: Transport + Send + 'static> TransportReader<T> {
             reader
                 .ctx
                 .spawn(move |ctx| {
-                    ctx.connections.as_mut().unwrap().disconnect(id).ok();
+                    ctx.connections.disconnect(id).ok();
                 })
                 .join()
                 .ok();

--- a/src/game/engine.rs
+++ b/src/game/engine.rs
@@ -17,7 +17,7 @@ use super::processing::{ProcessedText, TextInput, TextProcessor};
 pub struct GameEngine {
     pub aliases: TextProcessorManager<Alias>,
     pub completer: Option<Arc<Mutex<dyn CompletionSource + Send>>>,
-    pub history: History<String>,
+    pub history: Option<History<String>>,
 }
 
 impl Completer for Rc<Mutex<dyn CompletionSource>> {
@@ -47,7 +47,7 @@ impl Default for GameEngine {
         Self {
             aliases: TextProcessorManager::new(),
             completer: Some(Arc::new(Mutex::new(GameCompletionsFactory::create()))),
-            history: Default::default(),
+            history: Some(Default::default()),
         }
     }
 }
@@ -72,7 +72,9 @@ impl GameEngine {
             guard.process(text, ProcessFlags::SENT);
         }
 
-        self.history.insert(value.to_string());
+        if let Some(history) = &mut self.history {
+            history.insert(value.to_string());
+        }
 
         match self.aliases.process(TextInput::Line(value.into())) {
             Ok(ProcessedText::Removed(_)) => Ok(None),

--- a/src/input/commands/core.rs
+++ b/src/input/commands/core.rs
@@ -31,13 +31,7 @@ fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyRes
 
     if let Some(id) = connection_buffer_id {
         // make sure we disconnect if there are no more windows
-        let is_connected = context
-            .state_mut()
-            .connections
-            .as_mut()
-            .unwrap()
-            .by_buffer_id(id)
-            .is_some();
+        let is_connected = context.state_mut().connections.by_buffer_id(id).is_some();
         if is_connected
             && context
                 .state_mut()
@@ -50,12 +44,7 @@ fn quit_window(context: &mut CommandHandlerContext, args: HideBufArgs) -> KeyRes
                 .state_mut()
                 .echom(format!("{}: Disconnected.", name));
 
-            context
-                .state_mut()
-                .connections
-                .as_mut()
-                .unwrap()
-                .disconnect_buffer(id)?;
+            context.state_mut().connections.disconnect_buffer(id)?;
         }
     }
 

--- a/src/input/commands/helpers.rs
+++ b/src/input/commands/helpers.rs
@@ -23,13 +23,7 @@ pub fn buffer_connection_name(context: &CommandHandlerContext, id: Id) -> String
             format!("{:?}", buf.source())
         }
     } else {
-        let conn_id = context
-            .state()
-            .connections
-            .as_ref()
-            .unwrap()
-            .buffer_to_id(id)
-            .unwrap_or(id);
+        let conn_id = context.state().connections.buffer_to_id(id).unwrap_or(id);
         format!("Connection#{}", conn_id)
     }
 }
@@ -59,13 +53,7 @@ pub fn check_hide_buffer(context: &mut CommandHandlerContext, args: HideBufArgs)
     }
 
     if let Some(id) = connection_buffer_id {
-        let is_connected = context
-            .state_mut()
-            .connections
-            .as_mut()
-            .unwrap()
-            .by_buffer_id(id)
-            .is_some();
+        let is_connected = context.state_mut().connections.by_buffer_id(id).is_some();
 
         // disallow closing the main window
         let name = buffer_connection_name(context, id);
@@ -133,8 +121,6 @@ mod tests {
 
             state
                 .connections
-                .as_mut()
-                .unwrap()
                 .add_for_test(buf_id, Box::new(TestTransport));
 
             // we should not be able to hide a single, connected window

--- a/src/input/commands/script.rs
+++ b/src/input/commands/script.rs
@@ -44,12 +44,7 @@ fn reload_buffer_source(context: &mut CommandHandlerContext) -> KeyResult {
 
 fn source_path(context: &mut CommandHandlerContext, file_path: PathBuf) -> KeyResult {
     let buffer_id = context.state().current_buffer().id();
-    if let Some(conn) = context
-        .state_mut()
-        .connections
-        .as_mut()
-        .and_then(|conns| conns.by_buffer_id(buffer_id))
-    {
+    if let Some(conn) = context.state_mut().connections.by_buffer_id(buffer_id) {
         // Clear config on any associated connection
         conn.with_engine_mut(|engine| engine.reset());
     }

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -43,11 +43,9 @@ pub fn send_string_to_buffer<K: KeymapContext>(
 ) -> KeyResult {
     let mut sent = false;
 
-    if let Some(ref mut conns) = ctx.state_mut().connections {
-        if let Some(conn) = conns.by_buffer_id(conn_buffer_id) {
-            conn.send(to_send.clone())?;
-            sent = true;
-        }
+    if let Some(conn) = ctx.state_mut().connections.by_buffer_id(conn_buffer_id) {
+        conn.send(to_send.clone())?;
+        sent = true;
     }
 
     if sent {

--- a/src/input/maps/vim/cmdline.rs
+++ b/src/input/maps/vim/cmdline.rs
@@ -59,8 +59,7 @@ fn cmdline_to_prompt(
             if let Some(input_buffer_id) = ctx
                 .state_mut()
                 .connections
-                .as_mut()
-                .and_then(|conns| conns.by_buffer_id(conn_buffer_id))
+                .by_buffer_id(conn_buffer_id)
                 .map(|conn| conn.id)
                 .and_then(|conn_id| ctx.state().conn_input_buffer_id(conn_id))
             {

--- a/src/input/maps/vim/mod.rs
+++ b/src/input/maps/vim/mod.rs
@@ -256,8 +256,7 @@ fn pick_completer<K: KeymapContext>(mode: &VimMode, context: &mut K) -> Option<R
     } else if let Some(completer) = context
         .state_mut()
         .connections
-        .as_mut()
-        .and_then(|conns| conns.with_buffer_engine(buf_id, |eng| eng.completer.clone()))
+        .with_buffer_engine(buf_id, |eng| eng.completer.clone())
     {
         Some(Rc::new(completer))
     } else {

--- a/src/script/api/buffer.rs
+++ b/src/script/api/buffer.rs
@@ -33,11 +33,7 @@ impl BufferApiObject {
 
     #[rpc(passing(self.id))]
     fn connection_id(context: &mut CommandHandlerContext, buffer_id: Id) -> Option<Id> {
-        context
-            .state()
-            .connections
-            .as_ref()
-            .and_then(|conns| conns.buffer_to_id(buffer_id))
+        context.state().connections.buffer_to_id(buffer_id)
     }
 
     #[property]
@@ -67,14 +63,15 @@ impl BufferApiObject {
         replacement: Either<String, ScriptingFnRef>,
     ) -> KeyResult {
         let scripting = context.state().scripting.clone();
-        if let Some(ref mut conns) = context.state_mut().connections {
-            conns.with_buffer_engine(id, move |engine| match replacement {
+        context.state_mut().connections.with_buffer_engine(
+            id,
+            move |engine| match replacement {
                 Either::A(text) => engine.aliases.insert_text(pattern, text),
                 Either::B(f) => engine
                     .aliases
                     .insert_fn(pattern, create_user_processor(scripting, f)),
-            })?;
-        }
+            },
+        )?;
         Ok(())
     }
 }

--- a/src/script/api/connection.rs
+++ b/src/script/api/connection.rs
@@ -31,22 +31,15 @@ impl ConnectionApiObject {
 
     #[rpc(passing(self.id))]
     pub fn close(context: &mut CommandHandlerContext, id: Id) -> KeyResult {
-        if let Some(ref mut conns) = context.state_mut().connections {
-            let buffer_id = conns.disconnect(id)?;
+        let buffer_id = context.state_mut().connections.disconnect(id)?;
 
-            on_disconnect(context, buffer_id);
-        }
+        on_disconnect(context, buffer_id);
         Ok(())
     }
 
     #[rpc(passing(self.id))]
     pub fn send(context: &mut CommandHandlerContext, id: Id, text: String) -> KeyResult {
-        if let Some(conn_buffer_id) = context
-            .state_mut()
-            .connections
-            .as_ref()
-            .and_then(|conns| conns.id_to_buffer(id))
-        {
+        if let Some(conn_buffer_id) = context.state_mut().connections.id_to_buffer(id) {
             send_string_to_buffer(context, conn_buffer_id, text)
         } else {
             Err(KeyError::IO(std::io::ErrorKind::NotConnected.into()))

--- a/src/script/api/current.rs
+++ b/src/script/api/current.rs
@@ -46,8 +46,7 @@ impl CurrentObjects {
         context
             .state()
             .connections
-            .as_ref()
-            .and_then(|conns| conns.buffer_to_id(context.state().current_buffer().id()))
+            .buffer_to_id(context.state().current_buffer().id())
     }
 
     #[property]


### PR DESCRIPTION
Simplifies a bunch of code! There's one situation that we have to do some wacky tricks to avoid copying the entire input history, but I think it's worth it.