### PR TITLE
Add some basic Telnet handlers

### DIFF
--- a/src/app/looper.rs
+++ b/src/app/looper.rs
@@ -112,7 +112,7 @@ where
     // Main app loop:
     run_loop(&mut app_keys, map);
 
-    // kill any still-running jobs when the user wants to quit:
+    // Kill any still-running jobs when the user wants to quit:
     app_keys.state_mut().jobs.cancel_all();
 }
 

--- a/src/app/state.rs
+++ b/src/app/state.rs
@@ -337,6 +337,7 @@ impl Resizable for AppState {
     fn resize(&mut self, new_size: Size) {
         self.tabpages.resize(new_size);
         self.prompt.resize(new_size);
+        self.connections.resize(new_size);
     }
 }
 

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -47,6 +47,7 @@ impl ConnectionRecord {
 #[derive(Default)]
 pub struct Connections {
     ids: Ids,
+    app_size: Size,
     by_id: HashMap<Id, ConnectionRecord>,
     connection_to_buffer: HashMap<Id, Id>,
 
@@ -61,8 +62,9 @@ pub struct Connections {
 }
 
 impl Resizable for Connections {
-    fn resize(&mut self, _new_size: Size) {
-        // TODO notify connections
+    fn resize(&mut self, new_size: Size) {
+        let changed = self.app_size != new_size;
+        self.app_size = new_size;
     }
 }
 

--- a/src/connection/connections.rs
+++ b/src/connection/connections.rs
@@ -5,7 +5,7 @@ use url::Url;
 
 use crate::{
     app::jobs::{JobContext, JobRecord, Jobs},
-    editing::{ids::Ids, Id},
+    editing::{ids::Ids, Id, Resizable, Size},
     game::engine::GameEngine,
 };
 
@@ -58,6 +58,12 @@ pub struct Connections {
     factories: TransportFactories,
 
     buffer_engines: HashMap<Id, GameEngine>,
+}
+
+impl Resizable for Connections {
+    fn resize(&mut self, _new_size: Size) {
+        // TODO notify connections
+    }
 }
 
 impl Connections {

--- a/src/connection/flags.rs
+++ b/src/connection/flags.rs
@@ -1,0 +1,26 @@
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+};
+
+#[derive(Eq, PartialEq, Hash)]
+pub enum Flag {
+    NoEcho,
+}
+
+#[derive(Clone, Default)]
+pub struct Flags(Arc<Mutex<HashSet<Flag>>>);
+
+impl Flags {
+    pub fn add(&mut self, flag: Flag) {
+        self.0.lock().unwrap().insert(flag);
+    }
+
+    pub fn remove(&mut self, flag: Flag) {
+        self.0.lock().unwrap().remove(&flag);
+    }
+
+    pub fn can_echo(&self) -> bool {
+        !self.0.lock().unwrap().contains(&Flag::NoEcho)
+    }
+}

--- a/src/connection/game.rs
+++ b/src/connection/game.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use crate::game::engine::GameEngine;
+use crate::{editing::Size, game::engine::GameEngine};
 
 use super::{transport::Transport, ReadValue};
 
@@ -24,6 +24,10 @@ impl GameConnection {
 }
 
 impl Transport for GameConnection {
+    fn resize(&mut self, new_size: Size) -> io::Result<()> {
+        self.conn.lock().unwrap().resize(new_size)
+    }
+
     fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>> {
         // NOTE: The explicit scoping here and in send() are to ensure this
         // lock gets released before we attempt to access the next lock

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -2,7 +2,7 @@ use std::io;
 
 use url::Url;
 
-use crate::editing::text::TextLine;
+use crate::editing::{text::TextLine, Size};
 
 use self::{telnet::TelnetConnectionFactory, transport::Transport};
 
@@ -22,7 +22,7 @@ pub enum ReadValue {
 
 pub trait TransportFactory: Send + Sync {
     fn clone_boxed(&self) -> Box<dyn TransportFactory>;
-    fn create(&self, uri: &Url) -> Option<io::Result<Box<dyn Transport + Send>>>;
+    fn create(&self, uri: &Url, size: Size) -> Option<io::Result<Box<dyn Transport + Send>>>;
 }
 
 pub struct TransportFactories {
@@ -44,9 +44,9 @@ impl TransportFactories {
         }
     }
 
-    pub fn create(&self, uri: Url) -> io::Result<Box<dyn Transport + Send>> {
+    pub fn create(&self, uri: Url, size: Size) -> io::Result<Box<dyn Transport + Send>> {
         for f in &self.factories {
-            match f.create(&uri) {
+            match f.create(&uri, size) {
                 None => {} // unsupported
                 Some(Ok(conn)) => return Ok(conn),
                 Some(Err(e)) => return Err(e),

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -8,11 +8,14 @@ use self::{telnet::TelnetConnectionFactory, transport::Transport};
 
 mod ansi;
 pub mod connections;
+mod flags;
 pub mod game;
 mod reader;
 mod telnet;
 mod tls;
 pub mod transport;
+
+pub use flags::Flags;
 
 #[derive(Debug, PartialEq)]
 pub enum ReadValue {
@@ -20,9 +23,25 @@ pub enum ReadValue {
     Text(TextLine),
 }
 
+pub struct ConnectParams {
+    uri: Url,
+    size: Size,
+    flags: Flags,
+}
+
+impl ConnectParams {
+    pub fn with_uri_and_size(uri: Url, size: Size) -> Self {
+        Self {
+            uri,
+            size,
+            flags: Flags::default(),
+        }
+    }
+}
+
 pub trait TransportFactory: Send + Sync {
     fn clone_boxed(&self) -> Box<dyn TransportFactory>;
-    fn create(&self, uri: &Url, size: Size) -> Option<io::Result<Box<dyn Transport + Send>>>;
+    fn create(&self, params: &ConnectParams) -> Option<io::Result<Box<dyn Transport + Send>>>;
 }
 
 pub struct TransportFactories {
@@ -44,9 +63,9 @@ impl TransportFactories {
         }
     }
 
-    pub fn create(&self, uri: Url, size: Size) -> io::Result<Box<dyn Transport + Send>> {
+    pub fn create(&self, params: ConnectParams) -> io::Result<Box<dyn Transport + Send>> {
         for f in &self.factories {
-            match f.create(&uri, size) {
+            match f.create(&params) {
                 None => {} // unsupported
                 Some(Ok(conn)) => return Ok(conn),
                 Some(Err(e)) => return Err(e),
@@ -54,7 +73,7 @@ impl TransportFactories {
         }
         Err(io::Error::new(
             io::ErrorKind::InvalidInput,
-            format!("{}: Unsupported uri", uri),
+            format!("{}: Unsupported uri", params.uri),
         ))
     }
 }

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -122,7 +122,7 @@ impl TransportFactory for TelnetConnectionFactory {
             (Some(host), Some(port)) => match connect(host, port, secure, BUFFER_SIZE) {
                 Ok(conn) => Some(Ok(Box::new(TelnetConnection {
                     telnet: TelnetWrapper(conn),
-                    handlers: create_handlers(),
+                    handlers: Default::default(),
                     pipeline: AnsiPipeline::new(),
                 }))),
                 Err(e) => Some(Err(e)),
@@ -134,12 +134,4 @@ impl TransportFactory for TelnetConnectionFactory {
             ))),
         }
     }
-}
-
-fn create_handlers() -> TelnetHandlers {
-    let mut handlers: TelnetHandlers = Default::default();
-
-    handlers.register(ttype::create());
-
-    handlers
 }

--- a/src/connection/telnet.rs
+++ b/src/connection/telnet.rs
@@ -7,7 +7,7 @@ mod handlers;
 mod naws;
 mod ttype;
 
-use telnet::Telnet;
+use telnet::{Telnet, TelnetOption};
 use url::Url;
 
 use crate::editing::Size;
@@ -79,6 +79,15 @@ impl TelnetConnection {
 }
 
 impl Transport for TelnetConnection {
+    fn resize(&mut self, new_size: crate::editing::Size) -> io::Result<()> {
+        if let Some(naws) = self.handlers.get_mut(&TelnetOption::NAWS) {
+            if let Err(e) = naws.on_resize(&mut self.telnet.0, new_size) {
+                return Err(io::Error::new(io::ErrorKind::Other, e));
+            }
+        }
+        Ok(())
+    }
+
     fn read_timeout(&mut self, duration: std::time::Duration) -> io::Result<Option<ReadValue>> {
         if let Some(pending) = self.pipeline.next() {
             return Ok(Some(pending));

--- a/src/connection/telnet/echo.rs
+++ b/src/connection/telnet/echo.rs
@@ -1,0 +1,28 @@
+use telnet::TelnetOption;
+
+use crate::connection::{flags::Flag, Flags};
+
+use super::handler::{TelnetHandler, TelnetOptionHandler, TelnetOptionInteractor};
+
+pub struct EchoHandler {
+    flags: Flags,
+}
+
+impl TelnetHandler for EchoHandler {
+    fn on_remote_do(&mut self, _telnet: &mut telnet::Telnet) -> Result<(), telnet::TelnetError> {
+        self.flags.remove(Flag::NoEcho);
+        Ok(())
+    }
+
+    fn on_remote_dont(&mut self, _telnet: &mut telnet::Telnet) -> Result<(), telnet::TelnetError> {
+        self.flags.add(Flag::NoEcho);
+        Ok(())
+    }
+}
+
+pub fn create(flags: Flags) -> TelnetOptionHandler {
+    TelnetOptionHandler {
+        interactor: TelnetOptionInteractor::accept_do(TelnetOption::Echo),
+        handler: Box::new(EchoHandler { flags }),
+    }
+}

--- a/src/connection/telnet/handler.rs
+++ b/src/connection/telnet/handler.rs
@@ -61,11 +61,6 @@ impl TelnetOptionInteractor {
         Self::new(option, false, true)
     }
 
-    #[allow(unused)] // TODO clean up
-    pub fn accept_will(option: TelnetOption) -> Self {
-        Self::new(option, true, false)
-    }
-
     fn new(option: TelnetOption, accept_will: bool, accept_do: bool) -> Self {
         Self {
             option,

--- a/src/connection/telnet/handler.rs
+++ b/src/connection/telnet/handler.rs
@@ -1,0 +1,20 @@
+use telnet::{Telnet, TelnetError};
+
+pub trait TelnetHandler {
+    fn on_remote_will(&mut self, _telnet: &mut Telnet) -> Result<(), TelnetError> {
+        Ok(())
+    }
+    fn on_remote_wont(&mut self, _telnet: &mut Telnet) -> Result<(), TelnetError> {
+        Ok(())
+    }
+    fn on_remote_do(&mut self, _telnet: &mut Telnet) -> Result<(), TelnetError> {
+        Ok(())
+    }
+    fn on_remote_dont(&mut self, _telnet: &mut Telnet) -> Result<(), TelnetError> {
+        Ok(())
+    }
+
+    fn on_subnegotiate(&mut self, _telnet: &mut Telnet, _bytes: &[u8]) -> Result<(), TelnetError> {
+        Ok(())
+    }
+}

--- a/src/connection/telnet/handler.rs
+++ b/src/connection/telnet/handler.rs
@@ -51,11 +51,11 @@ impl TelnetOptionInteractor {
         Self::new(option, false, false)
     }
 
-    #[allow(unused)] // TODO clean up
     pub fn accept_do(option: TelnetOption) -> Self {
         Self::new(option, false, true)
     }
 
+    #[allow(unused)] // TODO clean up
     pub fn accept_will(option: TelnetOption) -> Self {
         Self::new(option, true, false)
     }

--- a/src/connection/telnet/handler.rs
+++ b/src/connection/telnet/handler.rs
@@ -1,6 +1,23 @@
-use telnet::{Telnet, TelnetError};
+use std::io;
+
+use telnet::{self, Telnet, TelnetError, TelnetOption};
 
 pub trait TelnetHandler {
+    fn negotiate(&mut self, action: &telnet::Action, telnet: &mut Telnet) -> io::Result<()> {
+        let result = match action {
+            telnet::Action::Do => self.on_remote_do(telnet),
+            telnet::Action::Dont => self.on_remote_dont(telnet),
+            telnet::Action::Will => self.on_remote_will(telnet),
+            telnet::Action::Wont => self.on_remote_wont(telnet),
+        };
+
+        if let Err(e) = result {
+            return Err(io::Error::new(io::ErrorKind::Other, e));
+        }
+
+        Ok(())
+    }
+
     fn on_remote_will(&mut self, _telnet: &mut Telnet) -> Result<(), TelnetError> {
         Ok(())
     }
@@ -16,5 +33,94 @@ pub trait TelnetHandler {
 
     fn on_subnegotiate(&mut self, _telnet: &mut Telnet, _bytes: &[u8]) -> Result<(), TelnetError> {
         Ok(())
+    }
+}
+
+pub struct TelnetOptionInteractor {
+    pub option: TelnetOption,
+
+    accept_will: bool,
+    accept_do: bool,
+
+    acked_will: bool,
+    acked_do: bool,
+}
+
+impl TelnetOptionInteractor {
+    pub fn default(option: TelnetOption) -> Self {
+        Self::new(option, false, false)
+    }
+
+    #[allow(unused)] // TODO clean up
+    pub fn accept_do(option: TelnetOption) -> Self {
+        Self::new(option, false, true)
+    }
+
+    pub fn accept_will(option: TelnetOption) -> Self {
+        Self::new(option, true, false)
+    }
+
+    fn new(option: TelnetOption, accept_will: bool, accept_do: bool) -> Self {
+        Self {
+            option,
+            accept_will,
+            accept_do,
+            acked_will: false,
+            acked_do: false,
+        }
+    }
+}
+
+impl TelnetHandler for TelnetOptionInteractor {
+    fn on_remote_will(&mut self, telnet: &mut Telnet) -> Result<(), TelnetError> {
+        match (self.accept_will, self.acked_will) {
+            (true, false) => {
+                crate::info!("## TELNET > Do {:?}", self.option);
+                self.acked_will = true;
+                telnet.negotiate(&telnet::Action::Do, self.option)
+            }
+            (false, false) => {
+                crate::info!("## TELNET > Dont {:?}", self.option);
+                self.acked_will = true;
+                telnet.negotiate(&telnet::Action::Dont, self.option)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    fn on_remote_do(&mut self, telnet: &mut Telnet) -> Result<(), TelnetError> {
+        match (self.accept_do, self.acked_do) {
+            (true, false) => {
+                crate::info!("## TELNET > Will {:?}", self.option);
+                self.acked_do = true;
+                telnet.negotiate(&telnet::Action::Will, self.option)
+            }
+            (false, false) => {
+                crate::info!("## TELNET > Wont {:?}", self.option);
+                self.acked_do = true;
+                telnet.negotiate(&telnet::Action::Wont, self.option)
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+pub struct TelnetOptionHandler {
+    pub interactor: TelnetOptionInteractor,
+    pub handler: Box<dyn TelnetHandler + Send>,
+}
+
+impl TelnetHandler for TelnetOptionHandler {
+    fn negotiate(&mut self, action: &telnet::Action, telnet: &mut Telnet) -> io::Result<()> {
+        self.interactor.negotiate(&action, telnet)?;
+        self.handler.negotiate(&action, telnet)
+    }
+
+    fn on_subnegotiate(&mut self, telnet: &mut Telnet, bytes: &[u8]) -> Result<(), TelnetError> {
+        if self.interactor.acked_will || self.interactor.acked_do {
+            self.handler.on_subnegotiate(telnet, bytes)
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/connection/telnet/handler.rs
+++ b/src/connection/telnet/handler.rs
@@ -2,6 +2,8 @@ use std::io;
 
 use telnet::{self, Telnet, TelnetError, TelnetOption};
 
+use crate::editing::Size;
+
 pub trait TelnetHandler {
     fn negotiate(&mut self, action: &telnet::Action, telnet: &mut Telnet) -> io::Result<()> {
         let result = match action {
@@ -15,6 +17,10 @@ pub trait TelnetHandler {
             return Err(io::Error::new(io::ErrorKind::Other, e));
         }
 
+        Ok(())
+    }
+
+    fn on_resize(&mut self, _telnet: &mut Telnet, _size: Size) -> Result<(), TelnetError> {
         Ok(())
     }
 

--- a/src/connection/telnet/handlers.rs
+++ b/src/connection/telnet/handlers.rs
@@ -1,0 +1,21 @@
+use std::collections::HashMap;
+
+use telnet::TelnetOption;
+
+use super::handler::TelnetOptionHandler;
+
+#[derive(Default)]
+pub struct TelnetHandlers {
+    handlers: HashMap<u8, TelnetOptionHandler>,
+}
+
+impl TelnetHandlers {
+    pub fn get_mut(&mut self, option: &TelnetOption) -> Option<&mut TelnetOptionHandler> {
+        self.handlers.get_mut(&option.as_byte())
+    }
+
+    pub fn register(&mut self, handler: TelnetOptionHandler) {
+        self.handlers
+            .insert(handler.interactor.option.as_byte(), handler);
+    }
+}

--- a/src/connection/telnet/handlers.rs
+++ b/src/connection/telnet/handlers.rs
@@ -2,11 +2,28 @@ use std::collections::HashMap;
 
 use telnet::TelnetOption;
 
-use super::handler::TelnetOptionHandler;
+use super::{handler::TelnetOptionHandler, ttype};
 
-#[derive(Default)]
 pub struct TelnetHandlers {
     handlers: HashMap<u8, TelnetOptionHandler>,
+}
+
+impl TelnetHandlers {
+    pub fn empty() -> Self {
+        Self {
+            handlers: Default::default(),
+        }
+    }
+}
+
+impl Default for TelnetHandlers {
+    fn default() -> Self {
+        let mut handlers = Self::empty();
+
+        handlers.register(ttype::create());
+
+        handlers
+    }
 }
 
 impl TelnetHandlers {

--- a/src/connection/telnet/handlers.rs
+++ b/src/connection/telnet/handlers.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use telnet::TelnetOption;
 
-use super::{handler::TelnetOptionHandler, ttype};
+use crate::editing::Size;
+
+use super::{handler::TelnetOptionHandler, naws, ttype};
 
 pub struct TelnetHandlers {
     handlers: HashMap<u8, TelnetOptionHandler>,
@@ -14,12 +16,11 @@ impl TelnetHandlers {
             handlers: Default::default(),
         }
     }
-}
 
-impl Default for TelnetHandlers {
-    fn default() -> Self {
+    pub fn with_size(size: Size) -> Self {
         let mut handlers = Self::empty();
 
+        handlers.register(naws::create(size));
         handlers.register(ttype::create());
 
         handlers

--- a/src/connection/telnet/handlers.rs
+++ b/src/connection/telnet/handlers.rs
@@ -2,9 +2,9 @@ use std::collections::HashMap;
 
 use telnet::TelnetOption;
 
-use crate::editing::Size;
+use crate::connection::ConnectParams;
 
-use super::{handler::TelnetOptionHandler, naws, ttype};
+use super::{echo, handler::TelnetOptionHandler, naws, ttype};
 
 pub struct TelnetHandlers {
     handlers: HashMap<u8, TelnetOptionHandler>,
@@ -17,10 +17,11 @@ impl TelnetHandlers {
         }
     }
 
-    pub fn with_size(size: Size) -> Self {
+    pub fn with_params(params: &ConnectParams) -> Self {
         let mut handlers = Self::empty();
 
-        handlers.register(naws::create(size));
+        handlers.register(echo::create(params.flags.clone()));
+        handlers.register(naws::create(params.size));
         handlers.register(ttype::create());
 
         handlers

--- a/src/connection/telnet/naws.rs
+++ b/src/connection/telnet/naws.rs
@@ -1,0 +1,34 @@
+use telnet::TelnetOption;
+
+use crate::editing::Size;
+
+use super::handler::{TelnetHandler, TelnetOptionHandler, TelnetOptionInteractor};
+
+pub struct NawsHandler {
+    pub size: Size,
+}
+
+impl NawsHandler {
+    fn send_size(&mut self, telnet: &mut telnet::Telnet) -> Result<(), telnet::TelnetError> {
+        let w = self.size.w.to_be_bytes();
+        let h = self.size.h.to_be_bytes();
+
+        crate::info!("## TELNET > IAC SB NAWS {} {}", self.size.w, self.size.h);
+
+        let message = [w, h].concat();
+        telnet.subnegotiate(TelnetOption::NAWS, &message)
+    }
+}
+
+impl TelnetHandler for NawsHandler {
+    fn on_remote_do(&mut self, telnet: &mut telnet::Telnet) -> Result<(), telnet::TelnetError> {
+        self.send_size(telnet)
+    }
+}
+
+pub fn create(size: Size) -> TelnetOptionHandler {
+    TelnetOptionHandler {
+        interactor: TelnetOptionInteractor::accept_do(TelnetOption::NAWS),
+        handler: Box::new(NawsHandler { size }),
+    }
+}

--- a/src/connection/telnet/naws.rs
+++ b/src/connection/telnet/naws.rs
@@ -24,6 +24,15 @@ impl TelnetHandler for NawsHandler {
     fn on_remote_do(&mut self, telnet: &mut telnet::Telnet) -> Result<(), telnet::TelnetError> {
         self.send_size(telnet)
     }
+
+    fn on_resize(
+        &mut self,
+        telnet: &mut telnet::Telnet,
+        size: Size,
+    ) -> Result<(), telnet::TelnetError> {
+        self.size = size;
+        self.send_size(telnet)
+    }
 }
 
 pub fn create(size: Size) -> TelnetOptionHandler {

--- a/src/connection/telnet/ttype.rs
+++ b/src/connection/telnet/ttype.rs
@@ -55,11 +55,6 @@ impl TTypeHandler {
 }
 
 impl TelnetHandler for TTypeHandler {
-    fn on_remote_do(&mut self, telnet: &mut telnet::Telnet) -> Result<(), TelnetError> {
-        crate::info!("## TELNET > Will TTYPE");
-        telnet.negotiate(&telnet::Action::Will, TelnetOption::TTYPE)
-    }
-
     fn on_remote_dont(&mut self, _telnet: &mut telnet::Telnet) -> Result<(), TelnetError> {
         self.state = TTypeRequestState::ClientName;
         Ok(())
@@ -82,7 +77,7 @@ impl TelnetHandler for TTypeHandler {
 
 pub fn create() -> TelnetOptionHandler {
     TelnetOptionHandler {
-        interactor: TelnetOptionInteractor::accept_will(TelnetOption::TTYPE),
+        interactor: TelnetOptionInteractor::accept_do(TelnetOption::TTYPE),
         handler: Box::new(TTypeHandler::default()),
     }
 }

--- a/src/connection/telnet/ttype.rs
+++ b/src/connection/telnet/ttype.rs
@@ -1,7 +1,7 @@
 use clap::crate_version;
 use telnet::{self, TelnetError, TelnetOption};
 
-use super::handler::TelnetHandler;
+use super::handler::{TelnetHandler, TelnetOptionHandler, TelnetOptionInteractor};
 
 const MTTS_ANSI: u16 = 1;
 const MTTS_UTF8: u16 = 4;
@@ -77,5 +77,12 @@ impl TelnetHandler for TTypeHandler {
         };
 
         self.send_state(telnet, state)
+    }
+}
+
+pub fn create() -> TelnetOptionHandler {
+    TelnetOptionHandler {
+        interactor: TelnetOptionInteractor::accept_will(TelnetOption::TTYPE),
+        handler: Box::new(TTypeHandler::default()),
     }
 }

--- a/src/connection/telnet/ttype.rs
+++ b/src/connection/telnet/ttype.rs
@@ -1,0 +1,81 @@
+use clap::crate_version;
+use telnet::{self, TelnetError, TelnetOption};
+
+use super::handler::TelnetHandler;
+
+const MTTS_ANSI: u16 = 1;
+const MTTS_UTF8: u16 = 4;
+const MTTS_256COLOR: u16 = 8;
+const MTTS_TRUE_COLOR: u16 = 256;
+
+const TELNET_IS: u8 = 0;
+
+#[derive(Clone, Copy)]
+enum TTypeRequestState {
+    ClientName,
+    TermType,
+    MttsBitVector,
+}
+
+pub struct TTypeHandler {
+    state: TTypeRequestState,
+}
+
+impl Default for TTypeHandler {
+    fn default() -> Self {
+        Self {
+            state: TTypeRequestState::ClientName,
+        }
+    }
+}
+
+impl TTypeHandler {
+    fn build_mtts_bitvector(&self) -> u16 {
+        // TODO Verify UTF8 support?
+        MTTS_ANSI + MTTS_UTF8 + MTTS_256COLOR + MTTS_TRUE_COLOR
+    }
+
+    fn send_state(
+        &self,
+        telnet: &mut telnet::Telnet,
+        state: TTypeRequestState,
+    ) -> Result<(), TelnetError> {
+        let name = match state {
+            TTypeRequestState::ClientName => format!("IAIDO {}", crate_version!()),
+            TTypeRequestState::TermType => "ANSI-TRUECOLOR".to_string(), // ?
+            TTypeRequestState::MttsBitVector => format!("MTTS {}", self.build_mtts_bitvector()),
+        };
+        let name_bytes = name.as_bytes();
+
+        crate::info!("## TELNET > IAC SB TTYPE IS {}", &name);
+
+        let message = [&[TELNET_IS], name_bytes].concat();
+        telnet.subnegotiate(TelnetOption::TTYPE, &message)
+    }
+}
+
+impl TelnetHandler for TTypeHandler {
+    fn on_remote_do(&mut self, telnet: &mut telnet::Telnet) -> Result<(), TelnetError> {
+        crate::info!("## TELNET > Will TTYPE");
+        telnet.negotiate(&telnet::Action::Will, TelnetOption::TTYPE)
+    }
+
+    fn on_remote_dont(&mut self, _telnet: &mut telnet::Telnet) -> Result<(), TelnetError> {
+        self.state = TTypeRequestState::ClientName;
+        Ok(())
+    }
+
+    fn on_subnegotiate(
+        &mut self,
+        telnet: &mut telnet::Telnet,
+        _bytes: &[u8],
+    ) -> Result<(), TelnetError> {
+        let state = self.state;
+        self.state = match state {
+            TTypeRequestState::ClientName => TTypeRequestState::TermType,
+            _ => TTypeRequestState::MttsBitVector,
+        };
+
+        self.send_state(telnet, state)
+    }
+}

--- a/src/connection/transport.rs
+++ b/src/connection/transport.rs
@@ -1,8 +1,16 @@
 use std::{io, time::Duration};
 
+use crate::editing::Size;
+
 use super::ReadValue;
 
 pub trait Transport {
     fn read_timeout(&mut self, duration: Duration) -> io::Result<Option<ReadValue>>;
     fn send(&mut self, text: &str) -> io::Result<()>;
+
+    // Optional:
+
+    fn resize(&mut self, _new_size: Size) -> io::Result<()> {
+        Ok(())
+    }
 }

--- a/src/editing/mod.rs
+++ b/src/editing/mod.rs
@@ -16,7 +16,7 @@ use std::ops;
 
 pub use buffer::Buffer;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub struct Size {
     pub w: u16,
     pub h: u16,

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -41,12 +41,12 @@ pub fn send_string_to_buffer<K: KeymapContext>(
     conn_buffer_id: Id,
     to_send: String,
 ) -> KeyResult {
-    let mut should_echo = true;
-
-    if let Some(conn) = ctx.state_mut().connections.by_buffer_id(conn_buffer_id) {
+    let should_echo = if let Some(conn) = ctx.state_mut().connections.by_buffer_id(conn_buffer_id) {
         conn.send(to_send.clone())?;
-        should_echo = conn.flags.can_echo();
-    }
+        conn.flags.can_echo()
+    } else {
+        return Err(KeyError::IO(io::ErrorKind::NotConnected.into()));
+    };
 
     if should_echo {
         if let Some(mut output) = ctx.state_mut().winsbuf_by_id(conn_buffer_id) {
@@ -64,8 +64,7 @@ pub fn send_string_to_buffer<K: KeymapContext>(
                 first.cursor = (last_line, 0).into();
             }
         }
-        return Ok(());
     }
 
-    Err(KeyError::IO(io::ErrorKind::NotConnected.into()))
+    Ok(())
 }

--- a/src/input/maps/actions/connection.rs
+++ b/src/input/maps/actions/connection.rs
@@ -41,14 +41,14 @@ pub fn send_string_to_buffer<K: KeymapContext>(
     conn_buffer_id: Id,
     to_send: String,
 ) -> KeyResult {
-    let mut sent = false;
+    let mut should_echo = true;
 
     if let Some(conn) = ctx.state_mut().connections.by_buffer_id(conn_buffer_id) {
         conn.send(to_send.clone())?;
-        sent = true;
+        should_echo = conn.flags.can_echo();
     }
 
-    if sent {
+    if should_echo {
         if let Some(mut output) = ctx.state_mut().winsbuf_by_id(conn_buffer_id) {
             output.append_value(ReadValue::Text(to_send.into()));
             output.append_value(ReadValue::Newline);

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ pub mod log;
 use crate::ui::backtrace::PanicData;
 use app::looper::app_loop;
 use backtrace::Backtrace;
+use editing::Resizable;
 use input::maps::vim::VimKeymap;
 use std::{
     io, panic,
@@ -27,6 +28,9 @@ fn main_loop() -> io::Result<()> {
     let ui = tui::create_ui()?;
     let state = app::State::default();
     let mut app = app::App::new(state, ui);
+
+    // Ensure app state has the initial size
+    app.state.resize(app.ui.size()?);
 
     if args.demo {
         demo::perform_demo(&mut app);

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -45,7 +45,15 @@ pub struct Tui {
 }
 
 impl Tui {
-    pub fn close(&mut self) -> Result<(), io::Error> {
+    pub fn size(&self) -> io::Result<Size> {
+        let size = self.terminal.size()?;
+        Ok(Size {
+            w: size.width,
+            h: size.height,
+        })
+    }
+
+    pub fn close(&mut self) -> io::Result<()> {
         // move the cursor to the bottom of the screen before leaving
         // so the terminal perserves output (hopefully)
         let size = self.terminal.size()?;


### PR DESCRIPTION
- Add rough initial support for MTTS; prepare to support NAWS
- Simplify telnet option handler creation
- Reorganize telnet handler registration into telnet::handlers
- Fix incorrect ttype option config + duplicate negotation
- Add basic NAWS support for initial terminal size
- Wire up resize dispatch to the TelnetConnection
- Respect telnet ECHO op
